### PR TITLE
feat: update to current docker standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ a quick start, follow these steps:
 
 3. **Start the Docker Containers:**
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 4. **Create an account:**
    ```bash

--- a/docker/all-in-one/docker-compose.yml
+++ b/docker/all-in-one/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   all-in-one:
     build:

--- a/docker/backend/docker-compose.yml
+++ b/docker/backend/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   hi-events-backend:
     build:

--- a/docker/development/docker-compose.dev.yml
+++ b/docker/development/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     backend:
         build:

--- a/docker/frontend/docker-compose.yml
+++ b/docker/frontend/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   hi-events-frontend:
     build:


### PR DESCRIPTION
1. The "version" Tag in the compose file is [obsolete](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element-obsolete)

2. `docker-compose` is from Compose-V1 but this stopped receiving updates, so this should be migrated to [V2](https://docs.docker.com/compose/migrate/)