### PR TITLE
Fix startup.sh not found when building on Windows

### DIFF
--- a/Dockerfile.all-in-one
+++ b/Dockerfile.all-in-one
@@ -37,7 +37,7 @@ COPY ./docker/all-in-one/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./docker/all-in-one/supervisor/supervisord.conf /etc/supervisord.conf
 
 COPY ./docker/all-in-one/scripts/startup.sh /startup.sh
-RUN chmod +x /startup.sh
+RUN dos2unix /startup.sh && chmod +x /startup.sh
 
 EXPOSE 80
 


### PR DESCRIPTION
This small PR fixes `startup.sh` file not being found in when building on Windows (Fixes https://github.com/HiEventsDev/hi.events/issues/5 and [Reddit comment](https://www.reddit.com/r/selfhosted/comments/1dabulx/comment/l7mci9p/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button))

The reason that this was occurring is because Windows saves the file with Windows line endings instead of the Unix line endings required by the Docker container. This is easily remedied by running `dos2unix` in the Dockerfile so that it doesn't need to be changed manually when building on Windows. 