### PR TITLE
Improve date and time display on event page

### DIFF
--- a/backend/config/mail.php
+++ b/backend/config/mail.php
@@ -98,8 +98,8 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
-        'name' => env('MAIL_FROM_NAME', 'Example'),
+        'address' => env('MAIL_FROM_ADDRESS', 'hello@hi.events'),
+        'name' => env('MAIL_FROM_NAME', 'Hi.Events'),
     ],
 
     /*

--- a/frontend/src/components/common/EventDateRange/index.tsx
+++ b/frontend/src/components/common/EventDateRange/index.tsx
@@ -1,0 +1,32 @@
+import {Event} from "../../../types.ts";
+import {formatDate} from "../../../utilites/dates.ts";
+
+interface EventDateRangeProps {
+    event: Event
+}
+
+export const EventDateRange = ({event}: EventDateRangeProps) => {
+    const startDateFormatted = formatDate(event.start_date, "ddd, MMM D, YYYY h:mm A", event.timezone);
+    const endDateFormatted = event.end_date ? formatDate(event.end_date, "ddd, MMM D, YYYY h:mm A", event.timezone) : null;
+    const sameDayFormatted = formatDate(event.start_date, "dddd, MMMM D", event.timezone);
+    const startTimeFormatted = formatDate(event.start_date, "h:mm A", event.timezone);
+    const endTimeFormatted = event.end_date ? formatDate(event.end_date, "h:mm A", event.timezone) : null;
+    const timezone = formatDate(event.start_date, "z", event.timezone);
+
+    const isSameDay = event.end_date && event.start_date.substring(0, 10) === event.end_date.substring(0, 10);
+
+    return (
+        <>
+            {isSameDay ? (
+                <span>
+                    {sameDayFormatted} · {startTimeFormatted} - {endTimeFormatted} {timezone}
+                </span>
+            ) : (
+                <span>
+                    {startDateFormatted}
+                    {endDateFormatted && ` - ${endDateFormatted}`} {timezone}
+                </span>
+            )}
+        </>
+    );
+}

--- a/frontend/src/components/forms/TicketForm/index.tsx
+++ b/frontend/src/components/forms/TicketForm/index.tsx
@@ -136,9 +136,9 @@ export const TicketForm = ({form, ticket}: TicketFormProps) => {
         },
         {
             icon: <IconHeartDollar/>,
-            label: t`Donation Ticket`,
+            label: t`Donation / Pay what you'd like ticket`,
             value: 'DONATION',
-            description: t`Set a minimum price and let users donate more`,
+            description: t`Set a minimum price and let users pay more if they choose`,
         },
         {
             icon: <IconCoins/>,

--- a/frontend/src/components/layouts/EventHomepage/EventInformation/index.tsx
+++ b/frontend/src/components/layouts/EventHomepage/EventInformation/index.tsx
@@ -9,6 +9,7 @@ import {ShareComponent} from "../../../common/ShareIcon";
 import {eventCoverImageUrl, eventHomepageUrl} from "../../../../utilites/urlHelper.ts";
 import {FC} from "react";
 import {Event} from "../../../../types.ts";
+import {EventDateRange} from "../../../common/EventDateRange";
 
 export const EventInformation: FC<{
     event: Event
@@ -39,15 +40,8 @@ export const EventInformation: FC<{
                     <h2>{t`Date & Time`}</h2>
                     <div className={classes.details}>
                         <IconCalendar size={20}/>
-                        <div className={classes.detail}>
-                            <div>
-                                {prettyDate(event.start_date, event.timezone)}
-                            </div>
-                            {event?.end_date && (
-                                <div>
-                                    {prettyDate(event.end_date, event.timezone)}
-                                </div>
-                            )}
+                        <div>
+                            <EventDateRange event={event}/>
                         </div>
                     </div>
                 </div>

--- a/frontend/src/utilites/dates.ts
+++ b/frontend/src/utilites/dates.ts
@@ -7,10 +7,12 @@ import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import advanced from 'dayjs/plugin/advancedFormat';
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
 dayjs.extend(timezone);
+dayjs.extend(advanced)
 
 export const prettyDate = (date: string, tz: string): string => {
     // eslint-disable-next-line lingui/no-unlocalized-strings


### PR DESCRIPTION
No end date
<img width="409" alt="Screenshot 2024-06-17 at 17 49 55" src="https://github.com/HiEventsDev/hi.events/assets/166798/44917609-af23-460b-87ab-923fd0ab7b4c">
Multi day
<img width="573" alt="Screenshot 2024-06-17 at 17 49 30" src="https://github.com/HiEventsDev/hi.events/assets/166798/417f1611-4d49-4e95-8536-f401dd8523fd">
Same day
<img width="435" alt="Screenshot 2024-06-17 at 17 49 14" src="https://github.com/HiEventsDev/hi.events/assets/166798/01e67d4e-9e85-41c3-a787-18e3bf6729c7">
