### PR TITLE
docs: add deploy to Zeabur as another one-click solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ a quick start, follow these steps:
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/8CGKmu?referralCode=KvSr11)
 
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/8DIRY6)
+
 ### 🐳 Quick Start with Docker
 
 > [!IMPORTANT]  


### PR DESCRIPTION
[Zeabur](https://zeabur.com) is a cloud hosting platform. I've created a template for users to deploy Hi.events with one click on Zeabur. 
Template: https://zeabur.com/templates/8DIRY6
Preview: https://tnbteb.zeabur.app/event/1/zeabur

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

