### PR TITLE
Allow larger files to be uploaded via the API

### DIFF
--- a/docker/all-in-one/nginx/nginx.conf
+++ b/docker/all-in-one/nginx/nginx.conf
@@ -29,6 +29,7 @@ http {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param REQUEST_URI $1;
             fastcgi_pass localhost:9000;
+            client_max_body_size 20M;
         }
 
        location ~ \.php$ {


### PR DESCRIPTION
Currently, any images added to events larger than 1MB will result in an error: `client intended to send too large body`. This is because the default [client_max_body_size] is 1 MB. This commit increases that limit to 20 MB so that larger images can be uploaded.

[client_max_body_size]: https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
