### PR TITLE
Improve ticket quantity edge cases

### DIFF
--- a/backend/app/Services/Domain/Order/OrderCreateRequestValidationService.php
+++ b/backend/app/Services/Domain/Order/OrderCreateRequestValidationService.php
@@ -196,8 +196,15 @@ class OrderCreateRequestValidationService
             ->flatten()
             ->min(fn(CapacityAssignmentDomainObject $capacity) => $capacity->getCapacity());
 
+        $ticketAvailableQuantity = $this->availableTicketQuantities
+            ->ticketQuantities
+            ->first(fn(AvailableTicketQuantitiesDTO $price) => $price->ticket_id === $ticket->getId())
+            ->quantity_available;
+
         # if there are fewer tickets available than the configured minimum, we allow less than the minimum to be purchased
-        $minPerOrder = min((int)$ticket->getMinPerOrder() ?: 1, $capacityMaximum ?: $maxPerOrder);
+        $minPerOrder = min((int)$ticket->getMinPerOrder() ?: 1,
+            $capacityMaximum ?: $maxPerOrder,
+            $ticketAvailableQuantity ?: $maxPerOrder);
 
         $this->validateTicketPricesQuantity(
             quantities: $ticketAndQuantities['quantities'],

--- a/frontend/src/components/common/NumberSelector/index.tsx
+++ b/frontend/src/components/common/NumberSelector/index.tsx
@@ -22,7 +22,7 @@ export const NumberSelector = ({formInstance, fieldName, min, max, sharedValues}
     const minValue = min || 0;
     const maxValue = max || 100;
 
-    const [sharedVals, setSharedVals] = useState<SharedValues>(sharedValues ?? new SharedValues(maxValue));
+    const [sharedVals] = useState<SharedValues>(sharedValues ?? new SharedValues(maxValue));
 
     useEffect(() => {
         formInstance.setFieldValue(fieldName, value);

--- a/frontend/src/components/routes/ticket-widget/SelectTickets/Prices/Tiered/index.tsx
+++ b/frontend/src/components/routes/ticket-widget/SelectTickets/Prices/Tiered/index.tsx
@@ -1,7 +1,7 @@
 import {Currency, TicketPriceDisplay} from "../../../../../common/Currency";
 import {Event, Ticket, TicketType} from "../../../../../../types.ts";
 import {Group, TextInput} from "@mantine/core";
-import {NumberSelector} from "../../../../../common/NumberSelector";
+import {NumberSelector, SharedValues} from "../../../../../common/NumberSelector";
 import {UseFormReturnType} from "@mantine/form";
 import {t} from "@lingui/macro";
 import {TicketPriceAvailability} from "../../../../../common/TicketPriceAvailability";
@@ -14,6 +14,8 @@ interface TieredPricingProps {
 }
 
 export const TieredPricing = ({ticket, event, form, ticketIndex}: TieredPricingProps) => {
+
+    const sharedValues = new SharedValues(Math.min(ticket.max_per_order ?? 100, ticket.quantity_available ?? 10000));
     return (
         <>
             {ticket?.prices?.map((price, index) => {
@@ -63,6 +65,7 @@ export const TieredPricing = ({ticket, event, form, ticketIndex}: TieredPricingP
                                             max={(Math.min(price.quantity_remaining ?? 50, ticket.max_per_order ?? 50))}
                                             fieldName={`tickets.${ticketIndex}.quantities.${index}.quantity`}
                                             formInstance={form}
+                                            sharedValues={sharedValues}
                                         />
                                         {form.errors[`tickets.${ticketIndex}.quantities.${index}.quantity`] && (
                                             <div className={'hi-ticket-quantity-error'}>


### PR DESCRIPTION
Just a variety of QoL changes regarding edge cases for ticket quantities (mostly frontend, one backend change regarding buying fewer than the minimum if there aren't enough tickets to reach the minimum).

1. Create shared values for all tiers of a given ticket, to ensure mins/maxes are adhered to and the overall maximum won't be exceeded.
    1. If a given tier has less available than the order minimum, incrementing will change the value for that tier to the tickets available. If you then increment another ticket tier, it will increase it only to the level that brings the order value up to the order minimum. (Example: two tiers, 5-ticket minimum. Tier 1 has 3 tickets remaining, and Tier 2 has no limit. If you increment Tier 1 from 0, it will increase to 3. If you then increment Tier 2, it will increase to 2, in order to reach a combined amount of 5)
    2. The overall ticket availability is shared between all tiers of a tiered ticket. (Example: If there are 5 tickets available, and you select 5 of one Tier, it will disable increments for all tiers. If you select 3 from one Tier, and 2 from another, it will disable increments for all tiers, as well)
3. Modify backend to allow user to buy fewer than the minimum order size if there aren't enough remaining tickets to meet the minimum order size. This only affects orders in which you are buying fewer than the configured minimum order size, AND you are buying all remaining tickets. (Example: if the configured min order size is 5, but there are 3 tickets remaining, you can buy 3 tickets. If the configured minimum order size is 5, the tickets remaining are 3, and you attempt to buy 2 tickets, it should reject the order)

In the below screenshots, there are 18 available tickets overall, only 3 Adult tickets remaining, and unlimited Student / Senior tickets.

![Screenshot 2024-09-15 at 12 38 33](https://github.com/user-attachments/assets/019fef51-f471-4378-92d0-e3f52032b926)
![Screenshot 2024-09-15 at 12 38 39](https://github.com/user-attachments/assets/c3c032d1-9889-4465-a5b4-72126dda982c)
![Screenshot 2024-09-15 at 12 38 46](https://github.com/user-attachments/assets/50e97273-73e0-44cd-b326-57f2015dbcfa)
![Screenshot 2024-09-15 at 12 44 53](https://github.com/user-attachments/assets/060b10b9-6f7b-4f25-8270-fda4ddb7b4b9)


## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
