### PR TITLE
Various semantic changes in email text, footer, and event page

### DIFF
--- a/backend/resources/views/emails/orders/attendee-ticket.blade.php
+++ b/backend/resources/views/emails/orders/attendee-ticket.blade.php
@@ -21,9 +21,8 @@
 {{ __('If you have any questions or need assistance, please reply to this email or contact the event organizer') }}
 {{ __('at') }} <a href="mailto:{{$eventSettings->getSupportEmail()}}">{{$eventSettings->getSupportEmail()}}</a>.
 
-{{ __('Best regards,') }}
-<br>
-{{config('app.name')}}
+{{ __('Best regards,') }}<br>
+{{ config('app.name') }}
 
 <script type="application/ld+json">
         {

--- a/backend/resources/views/emails/orders/order-cancelled.blade.php
+++ b/backend/resources/views/emails/orders/order-cancelled.blade.php
@@ -17,7 +17,7 @@
 {{ __('If you have any questions or need assistance, please respond to this email.') }}
 <br><br>
 {{ __('Thank you') }},<br>
-{{config('app.name')}}
+{{ config('app.name') }}
 
 {!! $eventSettings->getGetEmailFooterHtml() !!}
 </x-mail::message>

--- a/backend/resources/views/emails/orders/order-failed.blade.php
+++ b/backend/resources/views/emails/orders/order-failed.blade.php
@@ -17,9 +17,8 @@
 {{ __('If you have any questions or need assistance, feel free to reach out to our support team') }}
 {{ __('at') }} {{ $supportEmail ?? 'hello@hi.events' }}.
 
-{{ __('Best regards') }},
-<br>
-{{config('app.name')}}
+{{ __('Best regards') }},<br>
+{{ config('app.name') }}
 
 {!! $eventSettings->getGetEmailFooterHtml() !!}
 </x-mail::message>

--- a/backend/resources/views/emails/orders/order-refunded.blade.php
+++ b/backend/resources/views/emails/orders/order-refunded.blade.php
@@ -10,7 +10,8 @@
 
 {{ __('You have received a refund of :refundAmount for the following event: :eventTitle.', ['refundAmount' => $refundAmount, 'eventTitle' => $event->getTitle()]) }}
 
-{{ __('Thank you') }}
+{{ __('Thank you') }},<br>
+{{ config('app.name') }}
 
 {!! $eventSettings->getGetEmailFooterHtml() !!}
 </x-mail::message>

--- a/backend/resources/views/emails/orders/payment-success-but-order-expired.blade.php
+++ b/backend/resources/views/emails/orders/payment-success-but-order-expired.blade.php
@@ -20,7 +20,7 @@
 </x-mail::button>
 
 {{ __('Best regards') }},<br>
-{{ __('Hi.Events') }}
+{{ config('app.name') }}
 
 {!! $eventSettings->getGetEmailFooterHtml() !!}
 </x-mail::message>

--- a/backend/resources/views/emails/orders/summary.blade.php
+++ b/backend/resources/views/emails/orders/summary.blade.php
@@ -34,7 +34,6 @@
 - **{{ __('Prepare for the Event:') }}** {{ __('Make sure to note the event date, time, and location.') }}
 - **{{ __('Stay Updated:') }}** {{ __('Keep an eye on your email for any updates from the event organizer.') }}
 
-{{ __('Best regards,') }}
-<br>
+{{ __('Best regards,') }}<br>
 {{ config('app.name') }}
 </x-mail::message>

--- a/backend/resources/views/vendor/mail/html/message.blade.php
+++ b/backend/resources/views/vendor/mail/html/message.blade.php
@@ -36,9 +36,8 @@
                 {{-- You can find the full license text at: https://github.com/HiEventsDev/hi.events/blob/main/LICENSE --}}
                 {{-- In accordance with Section 7(b) of the AGPL, we ask that you retain the "Powered by Hi.Events" notice. --}}
                 {{-- If you wish to remove this notice, a commercial license is available at: https://hi.events/licensing --}}
-                © {{ date('Y') }} <a title="Manage events and sell tickets online with Hi.Events"
-                                     href="https://hi.events?utm_source=app-email-footer">Hi.Events</a> - Effortless
-                Event Management
+
+                © {{ date('Y') }} {{ config('app.app_name') }} | Powered by <a title="Manage events and sell tickets online with Hi.Events" href="https://hi.events?utm_source=app-email-footer">Hi.Events</a>
             @endif
         </x-mail::footer>
     </x-slot:footer>

--- a/backend/resources/views/vendor/mail/html/message.blade.php
+++ b/backend/resources/views/vendor/mail/html/message.blade.php
@@ -37,7 +37,7 @@
                 {{-- In accordance with Section 7(b) of the AGPL, we ask that you retain the "Powered by Hi.Events" notice. --}}
                 {{-- If you wish to remove this notice, a commercial license is available at: https://hi.events/licensing --}}
 
-                © {{ date('Y') }} {{ config('app.app_name') }} | Powered by <a title="Manage events and sell tickets online with Hi.Events" href="https://hi.events?utm_source=app-email-footer">Hi.Events</a>
+                © {{ date('Y') }} {{ config('app.name') }} | Powered by <a title="Manage events and sell tickets online with Hi.Events" href="https://hi.events?utm_source=app-email-footer">Hi.Events</a>
             @endif
         </x-mail::footer>
     </x-slot:footer>

--- a/frontend/src/components/common/EventDocumentHead/index.tsx
+++ b/frontend/src/components/common/EventDocumentHead/index.tsx
@@ -10,7 +10,7 @@ interface EventDocumentHeadProps {
 
 export const EventDocumentHead = ({event}: EventDocumentHeadProps) => {
     const eventSettings = event.settings;
-    const title = (eventSettings?.seo_title ?? event.title) + ' | ' + `Hi.Events`;
+    const title = (eventSettings?.seo_title ?? event.title) + ' | ' + event.organizer?.name;
     const description = eventSettings?.seo_description ?? event.description_preview;
     const keywords = eventSettings?.seo_keywords;
     const image = eventCoverImageUrl(event);


### PR DESCRIPTION
This is a minor change that modifies some text in emails and in the title of event pages.

1. It ensures all emails end with the app name, and normalizes the format of that section of the email
2. Changes the default email footer to "© `<year>` `<app-name>` | Powered by Hi.Events" with Hi.Events linked to https://hi.events?utm_source=app-email-footer. My thinking is that the actual content of the email may not be copyrighted to Hi.Events; and it changes the footer to the "Powered by" verbiage, as that's [what is in the LICENCE](https://github.com/HiEventsDev/Hi.Events/blob/develop/LICENCE#L1-L8), so it makes it consistent with the license and elsewhere in the code.
3. Changes the event page title to end with the organizer name instead of "Hi.Events" (i.e. "My Great Event | Cool Theater"). My thinking is that users should clearly know who is organizing the event.

Very open to thoughts on points 2 and 3.

## Checklist

- [X] I have read the contributing guidelines.
- [X] My code is of good quality and follows the coding standards of the project.
- [X] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
