### PR TITLE
Allow the header of emails to link to a webpage other than the app URL

### DIFF
--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -45,6 +45,7 @@ return [
     ],
 
     'email_logo_url' => env('APP_EMAIL_LOGO_URL'),
+    'email_logo_link_url' => env('APP_EMAIL_LOGO_LINK_URL', env('APP_FRONTEND_URL', 'http://localhost')),
     'email_footer_text' => env('APP_EMAIL_FOOTER_TEXT'),
 
     /*

--- a/backend/resources/views/vendor/mail/html/message.blade.php
+++ b/backend/resources/views/vendor/mail/html/message.blade.php
@@ -1,7 +1,7 @@
 <x-mail::layout>
     {{-- Header --}}
     <x-slot:header>
-        <x-mail::header :url="config('app.frontend_url')">
+        <x-mail::header :url="config('app.email_logo_link_url')">
             @if($appLogo = config('app.email_logo_url'))
                 <img src="{{ $appLogo }}" class="logo" alt="{{ config('app.name') }}"
                      style="max-width: 300px;">


### PR DESCRIPTION
This adds env variable that changes the webpage the logo will lead to when clicking on it in an email.

In most cases, we don't want customers to be routed to our events organizer login page when they click on the logo in an email. Instead, they can set another page (i.e. instead of events.mysite.com, they can just be sent to mysite.com)

## Checklist

- [X] I have read the contributing guidelines.
- [X] My code is of good quality and follows the coding standards of the project.
- [X] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
