### PR TITLE
Prevent arrow conversion to emoji; fix alignment of ticket elements

### DIFF
--- a/frontend/src/components/routes/ticket-widget/SelectTickets/Prices/Tiered/index.tsx
+++ b/frontend/src/components/routes/ticket-widget/SelectTickets/Prices/Tiered/index.tsx
@@ -21,7 +21,7 @@ export const TieredPricing = ({ticket, event, form, ticketIndex}: TieredPricingP
             {ticket?.prices?.map((price, index) => {
                 return (
                     <div key={index} className={'hi-price-tier-row'}>
-                        <Group justify={'space-between'}>
+                        <Group justify={'space-between'} wrap={'nowrap'}>
                             <div className={'hi-price-tier'}>
                                 <div className={'hi-price-tier-label'}>{price.label}</div>
                                 <div className={'hi-price-tier-price'}>

--- a/frontend/src/components/routes/ticket-widget/SelectTickets/index.tsx
+++ b/frontend/src/components/routes/ticket-widget/SelectTickets/index.tsx
@@ -33,7 +33,7 @@ import {PoweredByFooter} from "../../../common/PoweredByFooter";
 import {Event} from "../../../../types.ts";
 import {eventsClientPublic} from "../../../../api/event.client.ts";
 import {promoCodeClientPublic} from "../../../../api/promo-code.client.ts";
-import {IconX} from "@tabler/icons-react"
+import {IconX, IconNavigationFilled} from "@tabler/icons-react"
 import {getSessionIdentifier} from "../../../../utilites/sessionIdentifier.ts";
 import {Constants} from "../../../../constants.ts";
 
@@ -297,7 +297,7 @@ const SelectTickets = (props: SelectTicketsProps) => {
                                 .map((n) => n.toString());
                             quantityRange.unshift("0");
 
-                            const [ticketIsCollapsed, {toggle: collapseTicket}] = useDisclosure(!ticket.start_collapsed);
+                            const [ticketIsCollapsed, {toggle: collapseTicket}] = useDisclosure(ticket.start_collapsed);
 
                             return (
                                 <div key={ticket.id} className={'hi-ticket-row'}>
@@ -328,15 +328,14 @@ const SelectTickets = (props: SelectTicketsProps) => {
                                                 {(!ticket.is_available && ticket.type === 'TIERED') && (
                                                     <TicketAvailabilityMessage ticket={ticket} event={event}/>
                                                 )}
-
-                                                <span className={'hi-ticket-collapse-arrow'}>
-                                                    {ticketIsCollapsed ? '\u25BC' : '\u25B6'}
-                                                </span>
                                             </div>
+                                            <span className={`hi-ticket-collapse-arrow`}>
+                                                <IconNavigationFilled className={ticketIsCollapsed ? "" : "open"} />
+                                            </span>
                                         </UnstyledButton>
                                     </div>
 
-                                    <Collapse in={ticketIsCollapsed} className={'hi-ticket-content'}>
+                                    <Collapse in={!ticketIsCollapsed} className={'hi-ticket-content'}>
                                         <div className={'hi-price-tiers-rows'}>
                                             <TieredPricing
                                                 ticketIndex={ticketIndex}

--- a/frontend/src/components/routes/ticket-widget/SelectTickets/index.tsx
+++ b/frontend/src/components/routes/ticket-widget/SelectTickets/index.tsx
@@ -33,7 +33,7 @@ import {PoweredByFooter} from "../../../common/PoweredByFooter";
 import {Event} from "../../../../types.ts";
 import {eventsClientPublic} from "../../../../api/event.client.ts";
 import {promoCodeClientPublic} from "../../../../api/promo-code.client.ts";
-import {IconX, IconNavigationFilled} from "@tabler/icons-react"
+import {IconX, IconChevronRight} from "@tabler/icons-react"
 import {getSessionIdentifier} from "../../../../utilites/sessionIdentifier.ts";
 import {Constants} from "../../../../constants.ts";
 
@@ -330,7 +330,7 @@ const SelectTickets = (props: SelectTicketsProps) => {
                                                 )}
                                             </div>
                                             <span className={`hi-ticket-collapse-arrow`}>
-                                                <IconNavigationFilled className={ticketIsCollapsed ? "" : "open"} />
+                                                <IconChevronRight className={ticketIsCollapsed ? "" : "open"} />
                                             </span>
                                         </UnstyledButton>
                                     </div>

--- a/frontend/src/styles/widget/default.scss
+++ b/frontend/src/styles/widget/default.scss
@@ -40,6 +40,7 @@
           align-items: center;
 
           h3 {
+            flex: 1;
             margin: 10px 0;
 
             a {
@@ -48,13 +49,23 @@
           }
 
           .hi-ticket-title-metadata {
-            .hi-ticket-collapse-arrow {
-              color: var(--widget-secondary-color, var(--tk-primary));
-              margin-left: 10px;
-            }
-
             margin-left: 5px;
             font-weight: normal;
+          }
+
+          .hi-ticket-collapse-arrow {
+            display: flex;
+            color: var(--widget-secondary-color, var(--tk-primary));
+            margin-left: 10px;
+
+            svg {
+              transform: rotate(90deg);
+              transition: all 0.1s linear;
+            }
+
+            svg.open {
+              transform: rotate(180deg);
+            }
           }
         }
       }

--- a/frontend/src/styles/widget/default.scss
+++ b/frontend/src/styles/widget/default.scss
@@ -59,12 +59,11 @@
             margin-left: 10px;
 
             svg {
-              transform: rotate(90deg);
               transition: all 0.1s linear;
             }
 
             svg.open {
-              transform: rotate(180deg);
+              transform: rotate(90deg);
             }
           }
         }


### PR DESCRIPTION
On Safari (on iPhone), the right arrow is being converted to a ➡️ emoji, which is not desirable (FWIW, the down arrow is fine 🤷🏻‍♂️).

This changes the arrows from unicode arrows to an Icon, which also animates as the tickets open / close.

Also, fixes the inverted boolean logic around `ticketIsCollapsed`. Same exact functionality, I just had the boolean logic backwards on all of it.

Also, better aligns all the elements in the ticket title button.

<img width="927" alt="Screenshot 2024-10-31 at 13 18 56" src="https://github.com/user-attachments/assets/34900bca-c990-4baf-aae0-c3ae543a7297">
<img width="928" alt="Screenshot 2024-10-31 at 13 19 05" src="https://github.com/user-attachments/assets/dea0bf41-2d3a-4e66-b8f7-554cc674b83b">

---

Also fixes some alignment of ticket elements to ensure that the ticket counter is always on the right. If wrapping is necessary, the name of the tier should wrap.

BEFORE:

![22152AB2-87BE-4E63-8FB4-97A3D7983AFA_1_201_a](https://github.com/user-attachments/assets/a4075baa-d04e-4c5b-a7db-710595c5757b)

AFTER:

![18A1FE2B-AFE8-4632-8B1A-E9CCAF13B4A4_4_5005_c](https://github.com/user-attachments/assets/c7775314-d9ce-4723-b2a6-7590232a24f4)

---

## Checklist

- [X] I have read the contributing guidelines.
- [X] My code is of good quality and follows the coding standards of the project.
- [X] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
