### PR TITLE
Application Fee Calculation Adjustment for Stripe Integration

### DIFF
--- a/backend/app/Services/Domain/Payment/Stripe/StripePaymentIntentCreationService.php
+++ b/backend/app/Services/Domain/Payment/Stripe/StripePaymentIntentCreationService.php
@@ -61,7 +61,7 @@ class StripePaymentIntentCreationService
             $this->databaseManager->beginTransaction();
 
             $applicationFee = $this->getApplicationFee($paymentIntentDTO);
-
+            
             $paymentIntent = $this->stripeClient->paymentIntents->create([
                 'amount' => $paymentIntentDTO->amount,
                 'currency' => $paymentIntentDTO->currencyCode,
@@ -115,7 +115,7 @@ class StripePaymentIntentCreationService
         $fixedFee = $paymentIntentDTO->account->getApplicationFee()->fixedFee;
         $percentageFee = $paymentIntentDTO->account->getApplicationFee()->percentageFee;
 
-        return ceil(($fixedFee * 100) + ($paymentIntentDTO->amount * $percentageFee / 100));
+        return ceil(($fixedFee * 100) + ($paymentIntentDTO->order->getTotalBeforeAdditions() * $percentageFee));
     }
 
     /**


### PR DESCRIPTION
## Intent

The application fee calculation in SAAS mode needs adjustment. Currently, the application_fee_amount is being calculated based on the total amount (including processing fees), rather than the base ticket price.
 
### Current vs Expected Behavior

Using a A$5.00 ticket example:

Current Calculation:

```
Base price: A$5.00
Processing fee (2%): A$0.10
Subtotal: A$5.10
Application fee (3%): A$0.153 (3% of A$5.10)
application_fee_amount: 15.3 cents
```

Expected Calculation:

```
Base price: A$5.00
Application fee (3%): A$0.15 (3% of A$5.00)
application_fee_amount: 15 cents
Processing fee (2%): A$0.10
```

## Rationale

This change ensures that the application fee matches what organizers and customers expect - a straightforward percentage of the base ticket price. It makes the fee structure more transparent and predictable, as the application fee won't be influenced by processing fees.

## Testing

- Verified calculations with various ticket prices
- Tested with different fee percentages
- Confirmed Stripe integration works as expected


## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.
