### PR TITLE
Small Fix: Add wrap for translatable strings

### DIFF
--- a/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
+++ b/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
@@ -428,7 +428,7 @@ export const CollectInformation = () => {
                 buttonContent={order?.is_payment_required ? (
                     <Group gap={'10px'}>
                         <div style={{fontWeight: "bold"}}>
-                            Continue
+                            {t`Continue`}
                         </div>
                         <div style={{fontSize: 14}}>
                             {formatCurrency(order.total_gross, order.currency)}

--- a/frontend/src/components/routes/product-widget/Payment/index.tsx
+++ b/frontend/src/components/routes/product-widget/Payment/index.tsx
@@ -119,7 +119,7 @@ const Payment = () => {
                 buttonContent={order?.is_payment_required ? (
                     <Group gap={'10px'}>
                         <div style={{fontWeight: "bold"}}>
-                            Place Order
+                            {t`Place Order`}
                         </div>
                         <div style={{fontSize: 14}}>
                             {formatCurrency(order.total_gross, order.currency)}


### PR DESCRIPTION
Some strings on the frontend were missing translation wrapping, so I added it.

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
