### PR TITLE
Fix/sass deprecation warnings

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,8 +71,7 @@
     "sirv": "^2.0.4"
   },
   "devDependencies": {
-    "@lingui/cli": "^4.7.0",
-    "@lingui/vite-plugin": "^4.7.0",
+    "@lingui/vite-plugin": "^4.14.1",
     "@swc/core": "1.3.105",
     "@types/express": "^4.17.21",
     "@types/lodash": "^4.17.0",
@@ -81,8 +80,8 @@
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
-    "@vitejs/plugin-react": "^4.0.0",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react": "^4.4.1",
+    "@vitejs/plugin-react-swc": "^3.9.0",
     "babel-plugin-macros": "^3.1.0",
     "eslint": "^8.38.0",
     "eslint-plugin-lingui": "^0.2.0",
@@ -93,8 +92,8 @@
     "postcss-simple-vars": "^7.0.1",
     "sass": "^1.63.4",
     "typescript": "^5.0.2",
-    "vite": "^5.2.7",
-    "vite-bundle-visualizer": "^1.0.1",
+    "vite": "^5.4.19",
+    "vite-bundle-visualizer": "^1.2.1",
     "vite-plugin-copy": "^0.1.6"
   }
 }

--- a/frontend/src/components/common/AttendeeCheckInTable/QrScanner.module.scss
+++ b/frontend/src/components/common/AttendeeCheckInTable/QrScanner.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 @keyframes colorfulBorder {
   0% {
@@ -8,7 +8,7 @@
     border-color: #00000050;
   }
   100% {
-    border-color: #ffffff50
+    border-color: #ffffff50;
   }
 }
 
@@ -70,13 +70,13 @@
     animation: colorfulBorder 10s infinite;
     border-radius: 10px;
     outline: solid 50vmax rgb(71 46 120 / 50%);
-    transition: outline-color .2s ease-out;
+    transition: outline-color 0.2s ease-out;
     min-width: 200px;
     min-height: 200px;
 
-    @include respond-above(md) {
-        width: 40vw;
-        height: 40vw;
+    @include mixins.respond-above(md) {
+      width: 40vw;
+      height: 40vw;
     }
   }
 

--- a/frontend/src/components/common/AttendeeDetails/AttendeeDetails.module.scss
+++ b/frontend/src/components/common/AttendeeDetails/AttendeeDetails.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .orderDetails {
   display: flex;
@@ -11,7 +11,7 @@
     margin-bottom: var(--tk-spacing-md);
   }
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     flex-direction: column;
     flex-wrap: nowrap;
 

--- a/frontend/src/components/common/AttendeeTicket/AttendeeTicket.module.scss
+++ b/frontend/src/components/common/AttendeeTicket/AttendeeTicket.module.scss
@@ -1,10 +1,10 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .attendee {
   display: flex;
   justify-content: space-between;
   border-radius: 10px;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   border: 1px solid #ddd;
   overflow: hidden;
   padding: 0;
@@ -20,7 +20,7 @@
     }
   }
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     flex-direction: column-reverse;
   }
 
@@ -51,7 +51,7 @@
 
       .productPrice {
         .badge {
-          background-color: #8BC34A;
+          background-color: #8bc34a;
           color: #fff;
           padding: 5px 10px;
           border-radius: 10px;
@@ -71,7 +71,7 @@
     }
 
     a {
-      font-size: .9em;
+      font-size: 0.9em;
     }
   }
 
@@ -91,12 +91,11 @@
     border-left: 1px solid #ddd;
     padding: 15px;
 
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       border-left: none;
     }
 
-    .qrImage
-    {
+    .qrImage {
       svg {
         width: 140px;
         height: 140px;

--- a/frontend/src/components/common/CapacityAssignmentList/CapacityAssignmentList.module.scss
+++ b/frontend/src/components/common/CapacityAssignmentList/CapacityAssignmentList.module.scss
@@ -1,11 +1,11 @@
-@import '../../../styles/mixins';
+@use "../../../styles/mixins";
 
 .toolbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     flex-direction: column;
     align-items: flex-start;
   }
@@ -15,7 +15,7 @@
     margin-right: 20px;
     max-width: 320px;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       width: 100%;
       margin-bottom: 20px;
       max-width: 100%;
@@ -30,7 +30,7 @@
       height: 42px;
     }
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       width: 100%;
     }
   }
@@ -42,8 +42,7 @@
   gap: 20px;
   margin-top: 20px;
 
-  @include respond-below(md) {
-
+  @include mixins.respond-below(md) {
   }
 
   .capacityCard {
@@ -91,9 +90,7 @@
       }
 
       .capacityAssignmentActions {
-
       }
     }
   }
 }
-

--- a/frontend/src/components/common/CheckInListList/CheckInListList.module.scss
+++ b/frontend/src/components/common/CheckInListList/CheckInListList.module.scss
@@ -1,11 +1,11 @@
-@import '../../../styles/mixins';
+@use "../../../styles/mixins";
 
 .toolbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     flex-direction: column;
     align-items: flex-start;
   }
@@ -15,7 +15,7 @@
     margin-right: 20px;
     max-width: 320px;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       width: 100%;
       margin-bottom: 20px;
       max-width: 100%;
@@ -30,7 +30,7 @@
       height: 42px;
     }
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       width: 100%;
     }
   }
@@ -91,9 +91,7 @@
       }
 
       .checkInListActions {
-
       }
     }
   }
 }
-

--- a/frontend/src/components/common/EventCard/EventCard.module.scss
+++ b/frontend/src/components/common/EventCard/EventCard.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins.scss";
+@use "../../../styles/mixins.scss";
 
 .card {
   display: flex;
@@ -6,7 +6,7 @@
   overflow: hidden;
   padding: var(--mantine-spacing-sm) !important;
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     flex-direction: column;
     gap: 0px;
     padding: var(--mantine-spacing-md) !important;
@@ -31,7 +31,7 @@
     overflow: hidden;
     transition: background-size 15s ease;
 
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       flex-direction: row;
       gap: 20px;
       align-items: flex-start;
@@ -68,7 +68,7 @@
         font-weight: 500;
       }
 
-      @include respond-below(sm) {
+      @include mixins.respond-below(sm) {
         .day {
           font-size: 1.2em;
         }
@@ -83,7 +83,7 @@
     padding: var(--mantine-spacing-xs);
     flex: 1;
 
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       padding-left: 0;
       padding-bottom: 0;
     }
@@ -104,7 +104,7 @@
         }
       }
 
-      @include respond-below(sm) {
+      @include mixins.respond-below(sm) {
         flex-direction: column;
         align-items: flex-start;
         gap: 10px;
@@ -123,7 +123,7 @@
     justify-content: flex-end;
     margin: 0 10px;
 
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       align-items: flex-start;
       justify-content: flex-start;
       margin-bottom: var(--mantine-spacing-md);
@@ -137,7 +137,7 @@
       }
     }
 
-    @include respond-above(sm) {
+    @include mixins.respond-above(sm) {
       .mobileButton {
         display: none;
       }

--- a/frontend/src/components/common/NoResultsSplash/NoResultsSplash.module.scss
+++ b/frontend/src/components/common/NoResultsSplash/NoResultsSplash.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .container {
   display: flex;
@@ -14,7 +14,7 @@
     width: 240px;
     height: 240px;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       width: 170px;
       height: 170px;
     }

--- a/frontend/src/components/common/OrderDetails/OrderDetails.module.scss
+++ b/frontend/src/components/common/OrderDetails/OrderDetails.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .orderDetails {
   display: flex;
@@ -11,7 +11,7 @@
     margin-bottom: var(--tk-spacing-md);
   }
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     flex-direction: column;
     flex-wrap: nowrap;
 

--- a/frontend/src/components/common/OrdersTable/OrdersTable.module.scss
+++ b/frontend/src/components/common/OrdersTable/OrdersTable.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins.scss";
+@use "../../../styles/mixins.scss";
 
 .paymentStatus {
   text-transform: capitalize;
@@ -12,7 +12,7 @@
   margin-bottom: 15px;
   align-items: center;
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     flex-direction: column;
     align-items: flex-start;
   }
@@ -20,10 +20,10 @@
   & .colDetails {
     display: flex;
     flex-direction: column;
-    font-size: .9em;
+    font-size: 0.9em;
     max-width: 100%;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       margin-top: 10px;
       margin-bottom: 10px;
     }
@@ -32,12 +32,12 @@
       font-size: 1.1em;
       font-weight: 600;
       color: #333333;
-      @include ellipsis;
+      @include mixins.ellipsis;
     }
 
     .email {
       font-size: 0.9em;
-      @include ellipsis;
+      @include mixins.ellipsis;
     }
 
     .reference {
@@ -62,7 +62,7 @@
     align-items: flex-end;
     place-self: flex-start;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       width: 100%;
       align-items: flex-start;
     }
@@ -72,23 +72,23 @@
 
       .desktopAction {
         display: none;
-        @include respond-below(md) {
+        @include mixins.respond-below(md) {
           display: none;
         }
       }
 
       .mobileAction {
         display: none;
-        @include respond-below(md) {
+        @include mixins.respond-below(md) {
           display: block;
         }
       }
 
-      @include respond-above(md) {
+      @include mixins.respond-above(md) {
         place-content: flex-end;
       }
 
-      @include respond-below(md) {
+      @include mixins.respond-below(md) {
         width: 100%;
         > div {
           width: 100%;
@@ -104,7 +104,7 @@
       display: flex;
       margin-bottom: 20px;
 
-      @include respond-above(md) {
+      @include mixins.respond-above(md) {
         place-content: flex-end;
         margin-bottom: 35px;
       }

--- a/frontend/src/components/common/PageTitle/PageTitle.module.scss
+++ b/frontend/src/components/common/PageTitle/PageTitle.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins.scss";
+@use "../../../styles/mixins.scss";
 
 .container {
   margin-bottom: var(--tk-spacing-md);
@@ -8,7 +8,7 @@
   margin-bottom: 0.5rem !important;
   margin-top: 0;
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     font-size: 25px !important;
   }
 }

--- a/frontend/src/components/common/ProductsTable/ProductsTable.module.scss
+++ b/frontend/src/components/common/ProductsTable/ProductsTable.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins.scss";
+@use "../../../styles/mixins.scss";
 
 .sortableCategory {
   margin-bottom: 20px;
@@ -7,7 +7,7 @@
   padding: var(--tk-spacing-lg);
   box-shadow: 0 3px 0 #dddddd;
   border: 1px solid #e3e3e3;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
 .categoryHeader {
@@ -19,8 +19,8 @@
 }
 
 .categoryActions {
-    display: flex;
-    gap: 5px;
+  display: flex;
+  gap: 5px;
 }
 
 .categoryAction {
@@ -66,7 +66,8 @@
 }
 
 .dragOverlay {
-  .sortableCategory, .productCard {
+  .sortableCategory,
+  .productCard {
     transform: scale(1.05);
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
   }
@@ -81,7 +82,7 @@
   box-sizing: border-box;
   border-radius: var(--tk-radius-sm);
   border: 1px solid #e3e3e3;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   display: grid;
   padding: 20px;
   margin-bottom: 20px;
@@ -91,9 +92,10 @@
   grid-template-areas: "dragHanlde productInfo action";
   grid-template-columns: 40px 1fr 40px;
 
-  @include respond-below(lg) {
-    grid-template-areas: "dragHanlde productInfo"
-                         "dragHanlde action";
+  @include mixins.respond-below(lg) {
+    grid-template-areas:
+      "dragHanlde productInfo"
+      "dragHanlde action";
   }
 
   .halfCircle {
@@ -142,18 +144,18 @@
       flex-wrap: wrap;
       grid-template-columns: 1fr 1fr 1fr 1fr;
 
-      @include respond-below(lg) {
+      @include mixins.respond-below(lg) {
         flex-direction: column;
         align-items: flex-start;
         grid-template-columns: 1fr 1fr;
         gap: 20px;
       }
 
-      @include respond-below(sm) {
+      @include mixins.respond-below(sm) {
         gap: 10px;
       }
 
-      @include respond-below(xs) {
+      @include mixins.respond-below(xs) {
         gap: 20px;
         grid-template-columns: 1fr;
       }
@@ -162,7 +164,7 @@
         flex: 1;
         min-width: 125px;
 
-        @include respond-below(sm) {
+        @include mixins.respond-below(sm) {
           min-width: 100px;
         }
       }
@@ -170,7 +172,7 @@
       .heading {
         text-transform: uppercase;
         color: #9ca3af;
-        font-size: .8em;
+        font-size: 0.8em;
       }
 
       .status {
@@ -204,19 +206,19 @@
     display: flex;
     grid-area: action;
 
-    @include respond-below(lg) {
+    @include mixins.respond-below(lg) {
       margin-top: 10px;
     }
 
     .desktopAction {
-      @include respond-below(lg) {
+      @include mixins.respond-below(lg) {
         display: none;
       }
     }
 
     .mobileAction {
       display: none;
-      @include respond-below(lg) {
+      @include mixins.respond-below(lg) {
         display: block;
       }
     }

--- a/frontend/src/components/common/QuestionsTable/QuestionsTable.module.scss
+++ b/frontend/src/components/common/QuestionsTable/QuestionsTable.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins.scss";
+@use "../../../styles/mixins.scss";
 
 .outer {
   container-type: inline-size;
@@ -7,7 +7,7 @@
     gap: 15px;
     display: flex;
 
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       flex-direction: column;
     }
 
@@ -17,7 +17,7 @@
       align-items: center;
 
       .hiddenCount {
-        font-size: .9em;
+        font-size: 0.9em;
       }
 
       :global(.mantine-Switch-root) {
@@ -31,7 +31,7 @@
     flex-direction: row;
     gap: 20px;
 
-    @include respond-below(sm, true) {
+    @include mixins.respond-below(sm, true) {
       flex-direction: column;
     }
 
@@ -71,7 +71,6 @@
     }
 
     .defaultQuestionAlert {
-
     }
 
     .questions {
@@ -132,9 +131,4 @@
       }
     }
   }
-
 }
-
-
-
-

--- a/frontend/src/components/common/ReportTable/ReportTable.module.scss
+++ b/frontend/src/components/common/ReportTable/ReportTable.module.scss
@@ -1,7 +1,9 @@
-@import "../../../styles/mixins.scss";
+@use "../../../styles/mixins.scss";
 
-.periodSelect, .datePicker, .downloadButton {
-  @include respond-below(sm) {
+.periodSelect,
+.datePicker,
+.downloadButton {
+  @include mixins.respond-below(sm) {
     width: 100%;
   }
 }

--- a/frontend/src/components/common/Responsive/styles.module.scss
+++ b/frontend/src/components/common/Responsive/styles.module.scss
@@ -1,9 +1,9 @@
-@import '../../../styles/mixins';
+@use "../../../styles/mixins";
 
 .showForDesktop {
   display: none;
 
-  @include respond-above('md') {
+  @include mixins.respond-above("md") {
     display: block;
   }
 }
@@ -11,7 +11,7 @@
 .showForMobile {
   display: block;
 
-  @include respond-above('md') {
+  @include mixins.respond-above("md") {
     display: none;
   }
 }
@@ -19,7 +19,7 @@
 .hideForDesktop {
   display: block;
 
-  @include respond-above('md') {
+  @include mixins.respond-above("md") {
     display: none;
   }
 }
@@ -27,7 +27,7 @@
 .hideForMobile {
   display: none;
 
-  @include respond-above('md') {
+  @include mixins.respond-above("md") {
     display: block;
   }
 }

--- a/frontend/src/components/common/ScrollContainer/ScrollContainer.module.scss
+++ b/frontend/src/components/common/ScrollContainer/ScrollContainer.module.scss
@@ -1,9 +1,9 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .container {
   width: 100%;
   overflow-x: auto;
   box-sizing: border-box;
 
-  @include scrollbar;
+  @include mixins.scrollbar;
 }

--- a/frontend/src/components/common/SearchBar/SearchBar.module.scss
+++ b/frontend/src/components/common/SearchBar/SearchBar.module.scss
@@ -1,11 +1,11 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .searchBarWrapper {
   display: flex;
   align-items: center;
   gap: 10px;
 
-  @include respond-below(sm, true) {
+  @include mixins.respond-below(sm, true) {
     flex-direction: column;
   }
 
@@ -13,13 +13,12 @@
     margin-bottom: 0 !important;
     width: 100%;
 
-    @include respond-below(sm, true) {
+    @include mixins.respond-below(sm, true) {
       width: 100%;
     }
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       max-width: 100%;
     }
   }
 }
-

--- a/frontend/src/components/common/SortSelector/SortSelector.module.scss
+++ b/frontend/src/components/common/SortSelector/SortSelector.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .selectWrapper {
   width: 100%;
@@ -6,13 +6,12 @@
 
   .select {
     margin-bottom: 0 !important;
-    @include respond-above(lg) {
+    @include mixins.respond-above(lg) {
       max-width: 180px;
     }
 
     input {
-      font-size: .9em;
+      font-size: 0.9em;
     }
   }
 }
-

--- a/frontend/src/components/common/StatBoxes/StatBoxes.module.scss
+++ b/frontend/src/components/common/StatBoxes/StatBoxes.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins.scss";
+@use "../../../styles/mixins.scss";
 
 .statistics {
   display: grid;
@@ -7,11 +7,11 @@
   color: var(--tk-primary);
   margin: 0.5rem 0;
 
-  @include respond-below(lg) {
+  @include mixins.respond-below(lg) {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     grid-template-columns: 1fr;
   }
 }
@@ -43,7 +43,7 @@
       line-height: 1.2;
       align-self: end;
 
-      @include respond-below(md) {
+      @include mixins.respond-below(md) {
         font-size: 1.5rem;
       }
     }
@@ -70,7 +70,7 @@
       color: #ffffff;
       transition: transform 0.2s ease;
 
-      @include respond-below(md) {
+      @include mixins.respond-below(md) {
         width: 36px;
         height: 36px;
         border-radius: 10px;
@@ -82,7 +82,7 @@
     }
   }
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     padding: 1rem !important;
 
     .leftPanel {

--- a/frontend/src/components/common/Table/Table.module.scss
+++ b/frontend/src/components/common/Table/Table.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .tableHead {
   white-space: nowrap;
@@ -20,7 +20,9 @@
 }
 
 .table {
-  tr td, tr, th {
+  tr td,
+  tr,
+  th {
     padding: 15px !important;
     white-space: nowrap;
   }

--- a/frontend/src/components/common/ToolBar/ToolBar.module.scss
+++ b/frontend/src/components/common/ToolBar/ToolBar.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .card {
   container-type: inline-size;
@@ -10,7 +10,7 @@
     align-items: center;
     place-content: space-between;
 
-    @include respond-below(sm, true) {
+    @include mixins.respond-below(sm, true) {
       flex-direction: column;
       align-items: flex-start;
       width: 100%;
@@ -29,7 +29,7 @@
       align-items: center;
       place-self: flex-end;
 
-      @include respond-below(sm, true) {
+      @include mixins.respond-below(sm, true) {
         width: 100%;
         justify-content: flex-end;
       }

--- a/frontend/src/components/layouts/AuthLayout/Auth.module.scss
+++ b/frontend/src/components/layouts/AuthLayout/Auth.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins.scss";
+@use "../../../styles/mixins.scss";
 
 .authLayout {
   display: flex;
@@ -24,7 +24,7 @@
   background: transparent;
   overflow-y: auto;
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     width: 100%;
   }
 }
@@ -33,19 +33,19 @@
   width: 50%;
   position: relative;
   overflow: hidden;
-  background-image: url('/login-background.jpg');
+  background-image: url("/login-background.jpg");
   background-size: cover;
   background-position: center;
 
   &::before {
-    content: '';
+    content: "";
     position: absolute;
     inset: 0;
     background: linear-gradient(135deg, var(--tk-pink) 0%, #6d28d9 100%);
     opacity: 0.95;
   }
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     display: none;
   }
 }
@@ -145,7 +145,7 @@
   padding: 0 20px;
   min-width: 250px;
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     height: auto;
   }
 
@@ -155,14 +155,14 @@
     align-items: center;
     padding: 40px;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       padding: 20px;
     }
 
     img {
       width: 140px;
 
-      @include respond-below(md) {
+      @include mixins.respond-below(md) {
         width: 110px;
       }
     }
@@ -174,7 +174,7 @@
     margin-bottom: 3rem;
     position: relative;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       min-width: 80%;
       margin: 1rem;
     }

--- a/frontend/src/components/layouts/CheckIn/CheckIn.module.scss
+++ b/frontend/src/components/layouts/CheckIn/CheckIn.module.scss
@@ -1,9 +1,8 @@
-@import '../../../styles/mixins';
+@use "../../../styles/mixins";
 
 .container {
   min-width: 300px;
 }
-
 
 .header {
   position: sticky;
@@ -43,14 +42,14 @@
       }
 
       .scanButton {
-        @include respond-below(sm) {
+        @include mixins.respond-below(sm) {
           display: none;
         }
       }
 
       .scanIcon {
         display: none;
-        @include respond-below(sm) {
+        @include mixins.respond-below(sm) {
           display: flex;
         }
       }
@@ -62,7 +61,8 @@
   }
 }
 
-.loading, .noResults {
+.loading,
+.noResults {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/components/layouts/Checkout/Checkout.module.scss
+++ b/frontend/src/components/layouts/Checkout/Checkout.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .container {
   display: flex;
@@ -6,7 +6,7 @@
   height: 100vh;
 
   .sidebar {
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       display: none;
     }
   }
@@ -20,7 +20,7 @@
   }
 
   .subTitle {
-    font-size: .95em;
+    font-size: 0.95em;
     margin-top: 10px;
   }
 
@@ -59,11 +59,10 @@
         white-space: nowrap;
         text-overflow: ellipsis;
 
-        @include respond-below(md) {
+        @include mixins.respond-below(md) {
           width: calc(100vw - 60px);
           font-size: 1em;
         }
-
       }
     }
 
@@ -72,9 +71,9 @@
       height: calc(100vh - 90px);
       overflow-y: auto;
       padding: 20px 60px;
-      @include scrollbar();
+      @include mixins.scrollbar();
 
-      @include respond-below(md) {
+      @include mixins.respond-below(md) {
         padding: 20px;
       }
 

--- a/frontend/src/components/layouts/Checkout/CheckoutContent/CheckoutContent.module.scss
+++ b/frontend/src/components/layouts/Checkout/CheckoutContent/CheckoutContent.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../styles/mixins.scss";
+@use "../../../../styles/mixins.scss";
 
 .main {
   position: relative;
@@ -6,17 +6,17 @@
   overflow-y: auto;
   padding: 20px 60px;
 
+  @include mixins.scrollbar();
+
   &.hasFooter {
     height: calc(100vh - 60px);
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       height: calc(100vh - 110px);
     }
   }
 
-  @include scrollbar();
-
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     padding: 20px;
   }
 

--- a/frontend/src/components/layouts/Checkout/CheckoutFooter/CheckoutFooter.module.scss
+++ b/frontend/src/components/layouts/Checkout/CheckoutFooter/CheckoutFooter.module.scss
@@ -1,4 +1,4 @@
-@import '../../../../styles/mixins';
+@use "../../../../styles/mixins";
 
 .sidebar {
   width: auto !important;
@@ -17,7 +17,7 @@
   right: 0;
   z-index: 1;
   height: 100vh;
-  width: 100vw
+  width: 100vw;
 }
 
 .footer {
@@ -25,25 +25,11 @@
   bottom: 0;
   z-index: 2;
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     width: 100%;
   }
 
   .buttons {
-    .orderSummaryToggle {
-      display: block;
-
-      @include respond-above(md) {
-        display: none;
-      }
-    }
-
-    .continueButton {
-      margin-top: 20px;
-      flex: 1;
-      max-width: 700px;
-    }
-
     display: flex;
     gap: 10px;
     justify-content: center;
@@ -54,6 +40,20 @@
     box-shadow: 0px -5px 5px 0 rgba(0, 0, 0, 0.0392156863);
     border-top: 1px solid #e0e0e0;
 
+    .orderSummaryToggle {
+      display: block;
+
+      @include mixins.respond-above(md) {
+        display: none;
+      }
+    }
+
+    .continueButton {
+      margin-top: 20px;
+      flex: 1;
+      max-width: 700px;
+    }
+
     .continueButton {
       margin-top: 0;
     }
@@ -61,7 +61,7 @@
 }
 
 .orderComplete {
-  @include respond-above(md) {
+  @include mixins.respond-above(md) {
     display: none !important;
   }
 }

--- a/frontend/src/components/layouts/Checkout/CheckoutSidebar/CheckoutSidebar.module.scss
+++ b/frontend/src/components/layouts/Checkout/CheckoutSidebar/CheckoutSidebar.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../styles/mixins.scss";
+@use "../../../../styles/mixins.scss";
 
 .sidebar {
   width: 350px;
@@ -6,7 +6,7 @@
   background-color: #ffffff;
   max-height: 100vh;
   overflow-y: auto;
-  @include scrollbar();
+  @include mixins.scrollbar();
 
   .coverImage {
     img {

--- a/frontend/src/components/layouts/Event/Event.module.scss
+++ b/frontend/src/components/layouts/Event/Event.module.scss
@@ -1,10 +1,10 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .container {
   display: grid;
   grid-template-areas:
-          "topbar"
-           "main";
+    "topbar"
+    "main";
   grid-template-rows: 55px 1fr;
   grid-template-columns: 1fr;
   height: 100vh;
@@ -16,18 +16,18 @@
 
   @media (min-width: 768px) {
     grid-template-areas:
-            "sidebar topbar"
-            "sidebar main"
-            "sidebar main";
+      "sidebar topbar"
+      "sidebar main"
+      "sidebar main";
     grid-template-rows: 55px 1fr;
     grid-template-columns: 275px 1fr;
 
     &.closed {
       transform: none;
       grid-template-areas:
-            "topbar"
-            "main"
-            "main";
+        "topbar"
+        "main"
+        "main";
       grid-template-columns: 1fr;
     }
   }
@@ -48,12 +48,12 @@
       font-weight: 500;
       display: flex;
 
-      @include respond-below(md) {
+      @include mixins.respond-below(md) {
         display: none;
       }
     }
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       background-color: var(--tk-primary);
     }
 
@@ -62,8 +62,8 @@
     }
 
     .burger {
-      --burger-color : var(--tk-color-white);
-      @include respond-above(md) {
+      --burger-color: var(--tk-color-white);
+      @include mixins.respond-above(md) {
         display: none;
       }
     }
@@ -83,7 +83,7 @@
         max-width: 120px;
       }
 
-      @include respond-above(md) {
+      @include mixins.respond-above(md) {
         display: none;
       }
     }
@@ -94,19 +94,19 @@
       justify-content: flex-end;
 
       .eventPageButton {
-        @include respond-below(md) {
+        @include mixins.respond-below(md) {
           color: var(--tk-color-white);
         }
       }
     }
 
-    @include respond-above(md) {
+    @include mixins.respond-above(md) {
       background-color: white;
     }
   }
 
   &.closed {
-    @include respond-above(md) {
+    @include mixins.respond-above(md) {
       .sidebar {
         display: none;
       }
@@ -142,7 +142,7 @@
       background: transparent;
     }
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       position: fixed;
       width: 275px;
       height: 100vh;
@@ -173,7 +173,7 @@
         text-decoration: none;
         margin: 4px 10px;
         border-radius: var(--tk-radius-md);
-        font-size: .9em;
+        font-size: 0.9em;
         font-weight: 600;
 
         &.loading {
@@ -182,7 +182,8 @@
           height: 33px;
         }
 
-        &.linkActive, &:hover {
+        &.linkActive,
+        &:hover {
           background: #00000020;
           color: var(--tk-color-white);
         }
@@ -202,7 +203,7 @@
       right: -5px;
       top: 50%;
 
-      @include respond-below(md) {
+      @include mixins.respond-below(md) {
         display: none;
       }
     }
@@ -218,7 +219,7 @@
     left: -5px;
     top: 50%;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       display: none;
     }
   }
@@ -228,9 +229,9 @@
     padding: var(--tk-spacing-lg);
     overflow: auto;
 
-    @include scrollbar;
+    @include mixins.scrollbar;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       height: calc(100vh - 55px);
     }
   }

--- a/frontend/src/components/layouts/EventHomepage/EventHomepage.module.scss
+++ b/frontend/src/components/layouts/EventHomepage/EventHomepage.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins.scss";
+@use "../../../styles/mixins.scss";
 
 .background {
   position: fixed;
@@ -15,7 +15,7 @@
   top: 0;
   bottom: 0;
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     display: none;
   }
 }
@@ -35,18 +35,18 @@
   overflow: hidden;
   box-shadow: 0px 0px 6px 0px #00000025;
 
-  @include respond-above(md) {
+  @include mixins.respond-above(md) {
     min-width: 730px;
   }
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     margin: 0;
     border-radius: 0;
     box-shadow: none;
     width: 100%;
   }
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     border-radius: 0;
     margin: 0;
   }
@@ -61,7 +61,7 @@
     padding: 35px;
     width: 100%;
 
-    @include respond-below(md) {
+    @include mixins.respond-below(md) {
       min-height: 100vh;
       justify-content: space-between;
       padding: 20px;

--- a/frontend/src/components/layouts/EventHomepage/EventInformation/EventInformation.module.scss
+++ b/frontend/src/components/layouts/EventHomepage/EventInformation/EventInformation.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../styles/mixins";
+@use "../../../../styles/mixins";
 
 .preHeading {
   text-transform: uppercase;
@@ -13,7 +13,7 @@
     color: var(--homepage-secondary-color, var(--tk-color-black));
   }
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     font-size: 0.8rem;
   }
 }
@@ -24,7 +24,7 @@
   margin-bottom: 20px;
   margin-top: 0;
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     font-size: 1.5rem;
   }
 }
@@ -60,7 +60,7 @@
   }
 
   h2 {
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       font-size: 1rem;
     }
   }

--- a/frontend/src/components/layouts/EventHomepage/Header/Header.module.scss
+++ b/frontend/src/components/layouts/EventHomepage/Header/Header.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../styles/mixins.scss";
+@use "../../../../styles/mixins.scss";
 
 .header {
   display: flex;

--- a/frontend/src/components/layouts/EventHomepage/Header/index.tsx
+++ b/frontend/src/components/layouts/EventHomepage/Header/index.tsx
@@ -1,10 +1,10 @@
 import classes from './Header.module.scss'
-import {FC} from 'react';
-import {Event} from '../../../../types.ts';
+import { FC } from 'react';
+import { Event } from '../../../../types.ts';
 
 export const Header: FC<{
     event: Event
-}> = ({event}) => {
+}> = ({ event }) => {
 
     const coverImage = event?.images?.find((image) => image.type === 'EVENT_COVER');
 
@@ -16,7 +16,6 @@ export const Header: FC<{
         <>
             <header className={classes.header}>
                 <img
-                    loading={'lazy'}
                     alt={event?.title}
                     src={coverImage.url}
                 />

--- a/frontend/src/components/layouts/EventHomepage/index.tsx
+++ b/frontend/src/components/layouts/EventHomepage/index.tsx
@@ -1,14 +1,14 @@
-import {Header} from "./Header";
+import { Header } from "./Header";
 import "./styles.scss";
-import {EventInformation} from "./EventInformation";
+import { EventInformation } from "./EventInformation";
 import classes from "./EventHomepage.module.scss";
 import SelectProducts from "../../routes/product-widget/SelectProducts";
 import "../../../styles/widget/default.scss";
 import React from "react";
-import {EventDocumentHead} from "../../common/EventDocumentHead";
-import {eventCoverImageUrl} from "../../../utilites/urlHelper.ts";
-import {Event} from "../../../types.ts";
-import {EventNotAvailable} from "./EventNotAvailable";
+import { EventDocumentHead } from "../../common/EventDocumentHead";
+import { eventCoverImageUrl } from "../../../utilites/urlHelper.ts";
+import { Event } from "../../../types.ts";
+import { EventNotAvailable } from "./EventNotAvailable";
 
 interface EventHomepageProps {
     colors?: {
@@ -26,8 +26,8 @@ interface EventHomepageProps {
     promoCode?: string;
 }
 
-const EventHomepage = ({colors, continueButtonText, backgroundType, ...loaderData}: EventHomepageProps) => {
-    const {event, promoCodeValid, promoCode} = loaderData;
+const EventHomepage = ({ colors, continueButtonText, backgroundType, ...loaderData }: EventHomepageProps) => {
+    const { event, promoCodeValid, promoCode } = loaderData;
 
     const styleOverrides = {
         "--homepage-body-background-color":
@@ -45,7 +45,7 @@ const EventHomepage = ({colors, continueButtonText, backgroundType, ...loaderDat
     } as React.CSSProperties;
 
     if (!event) {
-        return <EventNotAvailable/>;
+        return <EventNotAvailable />;
     }
 
     const coverImage = eventCoverImageUrl(event);
@@ -56,12 +56,12 @@ const EventHomepage = ({colors, continueButtonText, backgroundType, ...loaderDat
             {(coverImage && backgroundType === 'MIRROR_COVER_IMAGE') && (
                 <div
                     className={classes.background}
-                    style={{backgroundImage: `url(${coverImage})`}}
+                    style={{ backgroundImage: `url(${coverImage})` }}
                 />
             )}
             {(!coverImage || backgroundType === 'COLOR') &&
                 <div className={classes.background}
-                     style={{backgroundColor: 'var(--homepage-body-background-color)'}}
+                    style={{ backgroundColor: 'var(--homepage-body-background-color)' }}
                 />
             }
             <div
@@ -69,10 +69,10 @@ const EventHomepage = ({colors, continueButtonText, backgroundType, ...loaderDat
                 className={classes.styleContainer}
             >
                 <div className={classes.container}>
-                    <Header event={event}/>
+                    <Header event={event} />
                     <div className={classes.innerContainer}>
                         <div className={classes.eventInfo}>
-                            <EventInformation event={event}/>
+                            <EventInformation event={event} />
                         </div>
 
                         <div className={classes.productContainer}>

--- a/frontend/src/components/modals/ManageOrderModal/ManageOrderModal.module.scss
+++ b/frontend/src/components/modals/ManageOrderModal/ManageOrderModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .container {
   padding: 0.5rem;

--- a/frontend/src/components/modals/RefundOrderModal/RefundOrderModal.module.scss
+++ b/frontend/src/components/modals/RefundOrderModal/RefundOrderModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/mixins";
+@use "../../../styles/mixins";
 
 .refundSummary {
   display: flex;
@@ -9,7 +9,7 @@
   border-radius: var(--tk-radius-lg);
   border: 3px solid var(--tk-secondary);
 
-  @include respond-below(md) {
+  @include mixins.respond-below(md) {
     flex-direction: column;
 
     .block {

--- a/frontend/src/components/routes/auth/Register/Register.module.scss
+++ b/frontend/src/components/routes/auth/Register/Register.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../styles/mixins.scss";
+@use "../../../../styles/mixins.scss";
 
 .header {
   text-align: center;

--- a/frontend/src/components/routes/event/GettingStarted/GettingStarted.module.scss
+++ b/frontend/src/components/routes/event/GettingStarted/GettingStarted.module.scss
@@ -1,10 +1,12 @@
-@import "../../../../styles/mixins.scss";
+@use "../../../../styles/mixins.scss";
 
 .headerCard {
-  background-image: url('/images/balloons.svg'), linear-gradient(358deg, #eee5ff, white);
+  background-image: url("/images/balloons.svg"), linear-gradient(358deg, #eee5ff, white);
   background-size: contain;
   background-repeat: no-repeat;
-  background-position: 95% 30px, 0 0;
+  background-position:
+    95% 30px,
+    0 0;
   box-shadow: none !important;
   padding: 30px;
 
@@ -12,7 +14,7 @@
     margin-bottom: 0px;
   }
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     background-image: linear-gradient(358deg, #eee5ff, white);
   }
 }
@@ -24,14 +26,14 @@
   flex-wrap: wrap;
   justify-content: space-between;
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     flex-direction: column;
   }
 
   & div {
     margin-bottom: 0px;
     width: calc(50% - 10px);
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       width: 100%;
     }
   }

--- a/frontend/src/components/routes/event/HomepageDesigner/HomepageDesigner.module.scss
+++ b/frontend/src/components/routes/event/HomepageDesigner/HomepageDesigner.module.scss
@@ -1,6 +1,6 @@
-@import "../../../../styles/mixins.scss";
+@use "../../../../styles/mixins.scss";
 
-@include respond-below(sm) {
+@include mixins.respond-below(sm) {
   :global(#event-manage-main) {
     overflow: auto;
   }
@@ -15,7 +15,7 @@
     margin-bottom: 0;
   }
 
-  @include respond-below(sm) {
+  @include mixins.respond-below(sm) {
     flex-direction: column;
   }
 
@@ -29,7 +29,7 @@
     position: sticky;
     top: 0;
 
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       width: 100%;
       min-width: unset;
       max-width: unset;
@@ -53,7 +53,7 @@
     overflow: hidden;
     min-width: 400px;
 
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       padding: 20px;
     }
 
@@ -68,7 +68,7 @@
       width: 100%;
       height: 100%;
       min-height: 500px;
-      --scale: .75;
+      --scale: 0.75;
 
       iframe {
         transform: scale(var(--scale));
@@ -85,7 +85,7 @@
       display: none;
     }
 
-    @include respond-below(sm) {
+    @include mixins.respond-below(sm) {
       > h2 {
         display: block;
       }

--- a/frontend/src/components/routes/product-widget/OrderSummaryAndProducts/OrderSummaryAndProducts.module.scss
+++ b/frontend/src/components/routes/product-widget/OrderSummaryAndProducts/OrderSummaryAndProducts.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../styles/mixins";
+@use "../../../../styles/mixins";
 
 .welcomeHeader {
   margin-bottom: 20px;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -1,4 +1,4 @@
-@import "mixins";
+@use "mixins";
 
 :root {
   --tk-text: #4b3b5d;
@@ -34,7 +34,7 @@
 }
 
 html {
-  height:auto;
+  height: auto;
 }
 
 body {
@@ -64,7 +64,7 @@ a {
 }
 
 .mantine-Modal-content {
-  @include scrollbar();
+  @include mixins.scrollbar();
 }
 
 .mantine-SimpleGrid-root {

--- a/frontend/src/styles/mixins.scss
+++ b/frontend/src/styles/mixins.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 $breakpoints: (
         'xs': 320px,
         'sm': 576px,
@@ -9,8 +11,8 @@ $breakpoints: (
 
 // Option to specify if the query should be a container query
 @mixin respond-above($breakpoint, $container-query: false) {
-  @if map-has-key($breakpoints, $breakpoint) {
-    $value: map-get($breakpoints, $breakpoint);
+  @if map.has-key($breakpoints, $breakpoint) {
+    $value: map.get($breakpoints, $breakpoint);
 
     @if $container-query {
       // Use container query
@@ -30,8 +32,8 @@ $breakpoints: (
 
 // Option to specify if the query should be a container query
 @mixin respond-below($breakpoint, $container-query: false) {
-  @if map-has-key($breakpoints, $breakpoint) {
-    $value: map-get($breakpoints, $breakpoint) - 1px;
+  @if map.has-key($breakpoints, $breakpoint) {
+    $value: map.get($breakpoints, $breakpoint) - 1px;
 
     @if $container-query {
       // Use container query

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,4 +31,11 @@ export default defineConfig({
     ssr: {
         noExternal: ["react-helmet-async"],
     },
+    css: {
+        preprocessorOptions: {
+            scss: {
+                api: "modern-compiler",
+            }
+        }
+    }
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -19,12 +19,26 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
+"@babel/code-frame@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
+  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.27.1"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.26.5":
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.5.tgz#df93ac37f4417854130e21d72c66ff3d4b897fc7"
   integrity sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==
 
-"@babel/core@^7.21.0", "@babel/core@^7.26.0":
+"@babel/compat-data@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.27.1.tgz#db7cf122745e0a332c44e847ddc4f5e5221a43f6"
+  integrity sha512-Q+E+rd/yBzNQhXkG+zQnF58e4zoZfBedaxwzPmicKsiK3nt8iJYrSrDbjwFFDGC4f+rPafqRaPH6TsDoSvMf7A==
+
+"@babel/core@^7.21.0":
   version "7.26.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.7.tgz#0439347a183b97534d52811144d763a17f9d2b24"
   integrity sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==
@@ -45,6 +59,27 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
+"@babel/core@^7.26.10":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.27.1.tgz#89de51e86bd12246003e3524704c49541b16c3e6"
+  integrity sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==
+  dependencies:
+    "@ampproject/remapping" "^2.2.0"
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.27.1"
+    "@babel/helper-compilation-targets" "^7.27.1"
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helpers" "^7.27.1"
+    "@babel/parser" "^7.27.1"
+    "@babel/template" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
 "@babel/generator@^7.21.1", "@babel/generator@^7.26.5":
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.5.tgz#e44d4ab3176bbcaf78a5725da5f1dc28802a9458"
@@ -52,6 +87,17 @@
   dependencies:
     "@babel/parser" "^7.26.5"
     "@babel/types" "^7.26.5"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
+
+"@babel/generator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.27.1.tgz#862d4fad858f7208edd487c28b58144036b76230"
+  integrity sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==
+  dependencies:
+    "@babel/parser" "^7.27.1"
+    "@babel/types" "^7.27.1"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
@@ -67,6 +113,17 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
+"@babel/helper-compilation-targets@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.1.tgz#eac1096c7374f161e4f33fc8ae38f4ddf122087a"
+  integrity sha512-2YaDd/Rd9E598B5+WIc8wJPmWETiiJXFYVE60oX8FDohv7rAUU3CQj+A1MgeEmcsk2+dQuEjIe/GDvig0SqL4g==
+  dependencies:
+    "@babel/compat-data" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
 "@babel/helper-module-imports@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz#e7f8d20602ebdbf9ebbea0a0751fb0f2a4141715"
@@ -74,6 +131,14 @@
   dependencies:
     "@babel/traverse" "^7.25.9"
     "@babel/types" "^7.25.9"
+
+"@babel/helper-module-imports@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz#7ef769a323e2655e126673bb6d2d6913bbead204"
+  integrity sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==
+  dependencies:
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
 "@babel/helper-module-transforms@^7.26.0":
   version "7.26.0"
@@ -83,6 +148,15 @@
     "@babel/helper-module-imports" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
     "@babel/traverse" "^7.25.9"
+
+"@babel/helper-module-transforms@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz#e1663b8b71d2de948da5c4fb2a20ca4f3ec27a6f"
+  integrity sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==
+  dependencies:
+    "@babel/helper-module-imports" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
 "@babel/helper-plugin-utils@^7.25.9":
   version "7.26.5"
@@ -94,15 +168,30 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
   integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
 
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
 "@babel/helper-validator-identifier@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
   integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
+"@babel/helper-validator-identifier@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
+  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
+
 "@babel/helper-validator-option@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz#86e45bd8a49ab7e03f276577f96179653d41da72"
   integrity sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==
+
+"@babel/helper-validator-option@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
+  integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
 
 "@babel/helpers@^7.26.7":
   version "7.26.7"
@@ -112,12 +201,27 @@
     "@babel/template" "^7.25.9"
     "@babel/types" "^7.26.7"
 
+"@babel/helpers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.27.1.tgz#ffc27013038607cdba3288e692c3611c06a18aa4"
+  integrity sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==
+  dependencies:
+    "@babel/template" "^7.27.1"
+    "@babel/types" "^7.27.1"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.22.0", "@babel/parser@^7.25.9", "@babel/parser@^7.26.5", "@babel/parser@^7.26.7":
   version "7.26.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.7.tgz#e114cd099e5f7d17b05368678da0fb9f69b3385c"
   integrity sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==
   dependencies:
     "@babel/types" "^7.26.7"
+
+"@babel/parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.1.tgz#c55d5bed74449d1223701f1869b9ee345cc94cc9"
+  integrity sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==
+  dependencies:
+    "@babel/types" "^7.27.1"
 
 "@babel/plugin-transform-react-jsx-self@^7.25.9":
   version "7.25.9"
@@ -149,6 +253,15 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
+"@babel/template@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.1.tgz#b9e4f55c17a92312774dfbdde1b3c01c547bbae2"
+  integrity sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@babel/parser" "^7.27.1"
+    "@babel/types" "^7.27.1"
+
 "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.7":
   version "7.26.7"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.7.tgz#99a0a136f6a75e7fb8b0a1ace421e0b25994b8bb"
@@ -162,6 +275,19 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
+"@babel/traverse@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.1.tgz#4db772902b133bbddd1c4f7a7ee47761c1b9f291"
+  integrity sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.27.1"
+    "@babel/parser" "^7.27.1"
+    "@babel/template" "^7.27.1"
+    "@babel/types" "^7.27.1"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.21.2", "@babel/types@^7.25.9", "@babel/types@^7.26.5", "@babel/types@^7.26.7":
   version "7.26.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.7.tgz#5e2b89c0768e874d4d061961f3a5a153d71dc17a"
@@ -169,6 +295,14 @@
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
+
+"@babel/types@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.1.tgz#9defc53c16fc899e46941fc6901a9eea1c9d8560"
+  integrity sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
 
 "@dnd-kit/accessibility@^3.1.1":
   version "3.1.1"
@@ -569,7 +703,7 @@
   resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-4.14.1.tgz#12f5a83bad1f9fef65fc22b8136ebd1052a31add"
   integrity sha512-X/2bKavX5HGaiLyGpGvw98XqrqKuTntD4IdLmwvCOh7c/pgM8u95brONixLFEBeLujba4IF+fvHo0RdlyOFKpg==
 
-"@lingui/cli@4.14.1", "@lingui/cli@^4.7.0":
+"@lingui/cli@4.14.1":
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/@lingui/cli/-/cli-4.14.1.tgz#062acbb088b05d4728890d9beb707a2168d8259e"
   integrity sha512-4DUtjHg5fumZ+hX8bcGYGZw9A6F5JURTMrI8Z6MSkO26OeSHEtPcheGFiPYfNhFeON6fZWZmwgyV9kkb0+psug==
@@ -662,7 +796,7 @@
     "@babel/runtime" "^7.20.13"
     "@lingui/core" "4.14.1"
 
-"@lingui/vite-plugin@^4.7.0":
+"@lingui/vite-plugin@^4.14.1":
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/@lingui/vite-plugin/-/vite-plugin-4.14.1.tgz#67e546e6c5e00be6883a694fe801b92d29db86a0"
   integrity sha512-K5lhG7IxpmxaDgmR4hOtPftJzCq3VGzq7VZnhBUHQPDxTf8fXj2xVNG3lUJtUkDepRhRLIjbCFT9e3f2VnUwZw==
@@ -1216,100 +1350,100 @@
   resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.54.2.tgz#0665848e22cbda936cfd05256facdfbba121438d"
   integrity sha512-R1PwtDvUfs99cAjfuQ/WpwJ3c92+DAMy9xGApjqlWQMj0FKQabUAys2swfTRNzuYAYJh7NqK2dzcYVNkKLEKUg==
 
-"@swc/core-darwin-arm64@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.15.tgz#1703ee8e98ea859965bfc7a912db4c452dc4ca36"
-  integrity sha512-zFdZ6/yHqMCPk7OhLFqHy/MQ1EqJhcZMpNHd1gXYT7VRU3FaqvvKETrUlG3VYl65McPC7AhMRfXPyJ0JO/jARQ==
+"@swc/core-darwin-arm64@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.24.tgz#c9fcc9c4bad0511fed26210449556d2b33fb2d9a"
+  integrity sha512-dhtVj0PC1APOF4fl5qT2neGjRLgHAAYfiVP8poJelhzhB/318bO+QCFWAiimcDoyMgpCXOhTp757gnoJJrheWA==
 
 "@swc/core-darwin-arm64@1.3.105":
   version "1.3.105"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.105.tgz#2960f8a87aed01b3850d5c37f05b51d9d3747141"
   integrity sha512-buWeweLVDXXmcnfIemH4PGnpjwsDTUGitnPchdftb0u1FU8zSSP/lw/pUCBDG/XvWAp7c/aFxgN4CyG0j7eayA==
 
-"@swc/core-darwin-x64@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.10.15.tgz#e8d60fc04ca56b1e5644b25f0032093a5bef70a0"
-  integrity sha512-8g4yiQwbr8fxOOjKXdot0dEkE5zgE8uNZudLy/ZyAhiwiZ8pbJ8/wVrDOu6dqbX7FBXAoDnvZ7fwN1jk4C8jdA==
+"@swc/core-darwin-x64@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.11.24.tgz#048ea3ee43281264a62fccb5a944b76d1c56eb24"
+  integrity sha512-H/3cPs8uxcj2Fe3SoLlofN5JG6Ny5bl8DuZ6Yc2wr7gQFBmyBkbZEz+sPVgsID7IXuz7vTP95kMm1VL74SO5AQ==
 
 "@swc/core-darwin-x64@1.3.105":
   version "1.3.105"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.105.tgz#aaa502f902dec1e4735a0a37a4fcc3a2c0369882"
   integrity sha512-hFmXPApqjA/8sy/9NpljHVaKi1OvL9QkJ2MbbTCCbJERuHMpMUeMBUWipHRfepGHFhU+9B9zkEup/qJaJR4XIg==
 
-"@swc/core-linux-arm-gnueabihf@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.15.tgz#1ec6d2caf1a8a099e13dcd459f45be2fb4febde8"
-  integrity sha512-rl+eVOltl2+7WXOnvmWBpMgh6aO13G5x0U0g8hjwlmD6ku3Y9iRcThpOhm7IytMEarUp5pQxItNoPq+VUGjVHg==
+"@swc/core-linux-arm-gnueabihf@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.24.tgz#f01ba657a81c67d8fb9f681712e65abf1324cec6"
+  integrity sha512-PHJgWEpCsLo/NGj+A2lXZ2mgGjsr96ULNW3+T3Bj2KTc8XtMUkE8tmY2Da20ItZOvPNC/69KroU7edyo1Flfbw==
 
 "@swc/core-linux-arm-gnueabihf@1.3.105":
   version "1.3.105"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.105.tgz#5a8629c75db4fe298ca3fdb18ecbc7888cd34759"
   integrity sha512-mwXyMC41oMKkKrPpL8uJpOxw7fyfQoVtIw3Y5p0Blabk+espNYqix0E8VymHdRKuLmM//z5wVmMsuHdGBHvZeg==
 
-"@swc/core-linux-arm64-gnu@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.15.tgz#dfcf6a63e9d6cb75779411e637c86ff7a04d352b"
-  integrity sha512-qxWEQeyAJMWJqjaN4hi58WMpPdt3Tn0biSK9CYRegQtvZWCbewr6v2agtSu5AZ2rudeH6OfCWAMDQQeSgn6PJQ==
+"@swc/core-linux-arm64-gnu@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.24.tgz#9aefca7f7f87c8312c2fa714c1eb731411d8596c"
+  integrity sha512-C2FJb08+n5SD4CYWCTZx1uR88BN41ZieoHvI8A55hfVf2woT8+6ZiBzt74qW2g+ntZ535Jts5VwXAKdu41HpBg==
 
 "@swc/core-linux-arm64-gnu@1.3.105":
   version "1.3.105"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.105.tgz#9cae768a92944774511a569dffca45f1beab7cdd"
   integrity sha512-H7yEIVydnUtqBSUxwmO6vpIQn7j+Rr0DF6ZOORPyd/SFzQJK9cJRtmJQ3ZMzlJ1Bb+1gr3MvjgLEnmyCYEm2Hg==
 
-"@swc/core-linux-arm64-musl@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.15.tgz#a629b47066f83730b757743145e2c8354a42164f"
-  integrity sha512-QcELd9/+HjZx0WCxRrKcyKGWTiQ0485kFb5w8waxcSNd0d9Lgk4EFfWWVyvIb5gIHpDQmhrgzI/yRaWQX4YSZQ==
+"@swc/core-linux-arm64-musl@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.24.tgz#e4805484779bbc59b639eab4f8e45166f3d7a4f7"
+  integrity sha512-ypXLIdszRo0re7PNNaXN0+2lD454G8l9LPK/rbfRXnhLWDBPURxzKlLlU/YGd2zP98wPcVooMmegRSNOKfvErw==
 
 "@swc/core-linux-arm64-musl@1.3.105":
   version "1.3.105"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.105.tgz#9244aabe4a7884d3d81df707d3e3c3478953a454"
   integrity sha512-Jg7RTFT3pGFdGt5elPV6oDkinRy7q9cXpenjXnJnM2uvx3jOwnsAhexPyCDHom8SHL0j+9kaLLC66T3Gz1E4UA==
 
-"@swc/core-linux-x64-gnu@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.15.tgz#2a5ec7ed21b38d6f07524ec6af6ae90c10ad3f63"
-  integrity sha512-S1+ZEEn3+a/MiMeQqQypbwTGoBG8/sPoCvpNbk+uValyygT+jSn3U0xVr45FbukpmMB+NhBMqfedMLqKA0QnJA==
+"@swc/core-linux-x64-gnu@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.24.tgz#e8d8cc50a49903880944379590b73733e150a5d4"
+  integrity sha512-IM7d+STVZD48zxcgo69L0yYptfhaaE9cMZ+9OoMxirNafhKKXwoZuufol1+alEFKc+Wbwp+aUPe/DeWC/Lh3dg==
 
 "@swc/core-linux-x64-gnu@1.3.105":
   version "1.3.105"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.105.tgz#7fde7b8a2ab7f5152e2dc37abf95f9add2c46937"
   integrity sha512-DJghplpyusAmp1X5pW/y93MmS/u83Sx5GrpJxI6KLPa82+NItTgMcl8KBQmW5GYAJpVKZyaIvBanS5TdR8aN2w==
 
-"@swc/core-linux-x64-musl@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.15.tgz#64bf2a9d4b3858a002a4879833245c25e742149b"
-  integrity sha512-qW+H9g/2zTJ4jP7NDw4VAALY0ZlNEKzYsEoSj/HKi7k3tYEHjMzsxjfsY9I8WZCft23bBdV3RTCPoxCshaj1CQ==
+"@swc/core-linux-x64-musl@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.24.tgz#f3c46212eb8a793f6a42a36b2a9017a9b1462737"
+  integrity sha512-DZByJaMVzSfjQKKQn3cqSeqwy6lpMaQDQQ4HPlch9FWtDx/dLcpdIhxssqZXcR2rhaQVIaRQsCqwV6orSDGAGw==
 
 "@swc/core-linux-x64-musl@1.3.105":
   version "1.3.105"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.105.tgz#a8d96fc532427f353696283c70ae13e7fcc18358"
   integrity sha512-wD5jL2dZH/5nPNssBo6jhOvkI0lmWnVR4vnOXWjuXgjq1S0AJpO5jdre/6pYLmf26hft3M42bteDnjR4AAZ38w==
 
-"@swc/core-win32-arm64-msvc@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.15.tgz#1c703c90873991b37a49df056af0f71bd632db5b"
-  integrity sha512-AhRB11aA6LxjIqut+mg7qsu/7soQDmbK6MKR9nP3hgBszpqtXbRba58lr24xIbBCMr+dpo6kgEapWt+t5Po6Zg==
+"@swc/core-win32-arm64-msvc@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.24.tgz#b1c3327d81a5f94415ac0b1713e192df1c121fbd"
+  integrity sha512-Q64Ytn23y9aVDKN5iryFi8mRgyHw3/kyjTjT4qFCa8AEb5sGUuSj//AUZ6c0J7hQKMHlg9do5Etvoe61V98/JQ==
 
 "@swc/core-win32-arm64-msvc@1.3.105":
   version "1.3.105"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.105.tgz#35edc1d898d7e9994fd6986b4c0085b3f1d59ec5"
   integrity sha512-UqJtwILUHRw2+3UTPnRkZrzM/bGdQtbR4UFdp79mZQYfryeOUVNg7aJj/bWUTkKtLiZ3o+FBNrM/x2X1mJX5bA==
 
-"@swc/core-win32-ia32-msvc@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.15.tgz#09f86d172b08913aaf0b96aa1596505cd95447af"
-  integrity sha512-UGdh430TQwbDn6KjgvRTg1fO022sbQ4yCCHUev0+5B8uoBwi9a89qAz3emy2m56C8TXxUoihW9Y9OMfaRwPXUw==
+"@swc/core-win32-ia32-msvc@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.24.tgz#6a944dd6111ec5fae3cf5925b73701e49b109edc"
+  integrity sha512-9pKLIisE/Hh2vJhGIPvSoTK4uBSPxNVyXHmOrtdDot4E1FUUI74Vi8tFdlwNbaj8/vusVnb8xPXsxF1uB0VgiQ==
 
 "@swc/core-win32-ia32-msvc@1.3.105":
   version "1.3.105"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.105.tgz#5e538fd63b648d8c5bf9c22371c5e273c208f961"
   integrity sha512-Z95C6vZgBEJ1snidYyjVKnVWiy/ZpPiIFIXGWkDr4ZyBgL3eZX12M6LzZ+NApHKffrbO4enbFyFomueBQgS2oA==
 
-"@swc/core-win32-x64-msvc@1.10.15":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.15.tgz#70bcf83837d331e5cebaf2195a1e696549fdfef3"
-  integrity sha512-XJzBCqO1m929qbJsOG7FZXQWX26TnEoMctS3QjuCoyBmkHxxQmZsy78KjMes1aomTcKHCyFYgrRGWgVmk7tT4Q==
+"@swc/core-win32-x64-msvc@1.11.24":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.24.tgz#eebb5d5ece2710aeb25cc58bd7c5c4c2c046f030"
+  integrity sha512-sybnXtOsdB+XvzVFlBVGgRHLqp3yRpHK7CrmpuDKszhj/QhmsaZzY/GHSeALlMtLup13M0gqbcQvsTNlAHTg3w==
 
 "@swc/core-win32-x64-msvc@1.3.105":
   version "1.3.105"
@@ -1335,24 +1469,24 @@
     "@swc/core-win32-ia32-msvc" "1.3.105"
     "@swc/core-win32-x64-msvc" "1.3.105"
 
-"@swc/core@^1.7.26":
-  version "1.10.15"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.10.15.tgz#41568ec332765d2798f56753fd56d7aeece48510"
-  integrity sha512-/iFeQuNaGdK7mfJbQcObhAhsMqLT7qgMYl7jX2GEIO+VDTejESpzAyKwaMeYXExN8D6e5BRHBCe7M5YlsuzjDA==
+"@swc/core@^1.11.21":
+  version "1.11.24"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.11.24.tgz#340425648296964f815c940b8da00fcdb1ff2abd"
+  integrity sha512-MaQEIpfcEMzx3VWWopbofKJvaraqmL6HbLlw2bFZ7qYqYw3rkhM0cQVEgyzbHtTWwCwPMFZSC2DUbhlZgrMfLg==
   dependencies:
     "@swc/counter" "^0.1.3"
-    "@swc/types" "^0.1.17"
+    "@swc/types" "^0.1.21"
   optionalDependencies:
-    "@swc/core-darwin-arm64" "1.10.15"
-    "@swc/core-darwin-x64" "1.10.15"
-    "@swc/core-linux-arm-gnueabihf" "1.10.15"
-    "@swc/core-linux-arm64-gnu" "1.10.15"
-    "@swc/core-linux-arm64-musl" "1.10.15"
-    "@swc/core-linux-x64-gnu" "1.10.15"
-    "@swc/core-linux-x64-musl" "1.10.15"
-    "@swc/core-win32-arm64-msvc" "1.10.15"
-    "@swc/core-win32-ia32-msvc" "1.10.15"
-    "@swc/core-win32-x64-msvc" "1.10.15"
+    "@swc/core-darwin-arm64" "1.11.24"
+    "@swc/core-darwin-x64" "1.11.24"
+    "@swc/core-linux-arm-gnueabihf" "1.11.24"
+    "@swc/core-linux-arm64-gnu" "1.11.24"
+    "@swc/core-linux-arm64-musl" "1.11.24"
+    "@swc/core-linux-x64-gnu" "1.11.24"
+    "@swc/core-linux-x64-musl" "1.11.24"
+    "@swc/core-win32-arm64-msvc" "1.11.24"
+    "@swc/core-win32-ia32-msvc" "1.11.24"
+    "@swc/core-win32-x64-msvc" "1.11.24"
 
 "@swc/counter@^0.1.1", "@swc/counter@^0.1.3":
   version "0.1.3"
@@ -1366,7 +1500,14 @@
   dependencies:
     tslib "^2.8.0"
 
-"@swc/types@^0.1.17", "@swc/types@^0.1.5":
+"@swc/types@^0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.21.tgz#6fcadbeca1d8bc89e1ab3de4948cef12344a38c0"
+  integrity sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==
+  dependencies:
+    "@swc/counter" "^0.1.3"
+
+"@swc/types@^0.1.5":
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.17.tgz#bd1d94e73497f27341bf141abdf4c85230d41e7c"
   integrity sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==
@@ -1972,23 +2113,23 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@vitejs/plugin-react-swc@^3.5.0":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.2.tgz#b0958dd44c48dbd37b5ef887bdb8b8d1276f24cd"
-  integrity sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==
+"@vitejs/plugin-react-swc@^3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react-swc/-/plugin-react-swc-3.9.0.tgz#4db7fc9a31c52b16cc778ddfd6fb6ade02e9b36a"
+  integrity sha512-jYFUSXhwMCYsh/aQTgSGLIN3Foz5wMbH9ahb0Zva//UzwZYbMiZd7oT3AU9jHT9DLswYDswsRwPU9jVF3yA48Q==
   dependencies:
-    "@swc/core" "^1.7.26"
+    "@swc/core" "^1.11.21"
 
-"@vitejs/plugin-react@^4.0.0":
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz#c64be10b54c4640135a5b28a2432330e88ad7c20"
-  integrity sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==
+"@vitejs/plugin-react@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.4.1.tgz#d7d1e9c9616d7536b0953637edfee7c6cbe2fe0f"
+  integrity sha512-IpEm5ZmeXAP/osiBXVVP5KjFMzbWOonMs0NaQQl+xYnUAcq4oHUBsF2+p4MgKWG4YMmFYJU8A6sxRPuowllm6w==
   dependencies:
-    "@babel/core" "^7.26.0"
+    "@babel/core" "^7.26.10"
     "@babel/plugin-transform-react-jsx-self" "^7.25.9"
     "@babel/plugin-transform-react-jsx-source" "^7.25.9"
     "@types/babel__core" "^7.20.5"
-    react-refresh "^0.14.2"
+    react-refresh "^0.17.0"
 
 "@web3-storage/multipart-parser@^1.0.0":
   version "1.0.0"
@@ -4567,10 +4708,10 @@ react-qr-code@^2.0.12:
     prop-types "^15.8.1"
     qr.js "0.0.0"
 
-react-refresh@^0.14.2:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
-  integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
+react-refresh@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
+  integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
 react-remove-scroll-bar@^2.3.7:
   version "2.3.8"
@@ -5367,7 +5508,7 @@ victory-vendor@^36.6.8:
     d3-time "^3.0.0"
     d3-timer "^3.0.1"
 
-vite-bundle-visualizer@^1.0.1:
+vite-bundle-visualizer@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/vite-bundle-visualizer/-/vite-bundle-visualizer-1.2.1.tgz#8be34033f0216de529abec4b18a8b62aa1b65c9e"
   integrity sha512-cwz/Pg6+95YbgIDp+RPwEToc4TKxfsFWSG/tsl2DSZd9YZicUag1tQXjJ5xcL7ydvEoaC2FOZeaXOU60t9BRXw==
@@ -5393,10 +5534,10 @@ vite-plugin-copy@^0.1.6:
   dependencies:
     fast-glob "^3.2.7"
 
-vite@^5.2.7:
-  version "5.4.14"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.14.tgz#ff8255edb02134df180dcfca1916c37a6abe8408"
-  integrity sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==
+vite@^5.4.19:
+  version "5.4.19"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.19.tgz#20efd060410044b3ed555049418a5e7d1998f959"
+  integrity sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==
   dependencies:
     esbuild "^0.21.3"
     postcss "^8.4.43"


### PR DESCRIPTION
## Sass legacy JS API
The API is used by vite. Vite 5.4 has a config option to enable sass's new API. That fixes that issue. To achive this the minor version of dev dependencies got bumped. Minor versions do not include breaking changes.

## Sass @import rule
The syntax for `@import "mixins"` in all .scss files got changed. Additionally the old global built-in functions `map-has-key()` and `map-get()` got replaced with `map.has-key()` and `map.get()`. Moreover, all rules like `display: block` have to be at the top when using nesting to obide vanilla css rules.

Fixes #522.

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉

P. S. Consider a bot that automatically updates minor versions