### PR TITLE
Fix downloading all languages

### DIFF
--- a/frontend/src/entry.client.tsx
+++ b/frontend/src/entry.client.tsx
@@ -5,7 +5,7 @@ import {hydrate} from "@tanstack/react-query";
 import {router} from "./router";
 import {App} from "./App";
 import {queryClient} from "./utilites/queryClient";
-import {getClientLocale} from "./locales.ts";
+import {dynamicActivateLocale, getClientLocale, getSupportedLocale} from "./locales.ts";
 
 declare global {
     interface Window {
@@ -18,6 +18,7 @@ if (window.__REHYDRATED_STATE__) {
 }
 
 async function initClientApp() {
+    dynamicActivateLocale(getSupportedLocale(getClientLocale()));
     // Determine if any of the initial routes are lazy
     const lazyMatches = matchRoutes(router, window.location)?.filter(
         (m) => m.route.lazy

--- a/frontend/src/locales.ts
+++ b/frontend/src/locales.ts
@@ -1,40 +1,9 @@
-// @ts-ignore
-import {messages as en} from "./locales/en.po";
-// @ts-ignore
-import {messages as de} from "./locales/de.po";
-// @ts-ignore
-import {messages as fr} from "./locales/fr.po";
-// @ts-ignore
-import {messages as nl} from "./locales/nl.po";
-// @ts-ignore
-import {messages as pt} from "./locales/pt.po";
-// @ts-ignore
-import {messages as es} from "./locales/es.po";
-// @ts-ignore
-import {messages as zhCn} from "./locales/zh-cn.po";
-// @ts-ignore
-import {messages as zhHk} from "./locales/zh-hk.po";
-// @ts-ignore
-import {messages as ptBr} from "./locales/pt-br.po";
-// @ts-ignore
-import {messages as vi} from "./locales/vi.po";
 import {i18n} from "@lingui/core";
 import {t} from "@lingui/macro";
 
 export type SupportedLocales = "en" | "de" | "fr" | "nl" | "pt" | "es" | "zh-cn" | "pt-br" | "vi" |"zh-hk";
 
-export const localeMessages: Record<string, any> = {
-    en: en,
-    de: de,
-    fr: fr,
-    nl: nl,
-    pt: pt,
-    es: es,
-    "zh-cn": zhCn,
-    "zh-hk": zhHk,
-    "pt-br": ptBr,
-    vi: vi,
-};
+export const availableLocales = ["en", "de", "fr", "nl", "pt", "es", "zh-cn", "zh-hk", "pt-br", "vi",];
 
 export const localeToFlagEmojiMap: Record<SupportedLocales, string> = {
     en: '🇬🇧',
@@ -85,24 +54,21 @@ export const getClientLocale = () => {
 };
 
 export async function dynamicActivateLocale(locale: string) {
-    try {
-        const messages = localeMessages[locale] || localeMessages["en"];
-        i18n.load(locale, messages);
+        locale = availableLocales.includes(locale) ? locale : "en";
+        const module = (await import(`./locales/${locale}.po`));
+        i18n.load(locale, module.messages);
         i18n.activate(locale);
-    } catch (error) {
-        i18n.activate("en");
-    }
 }
 
 export const getSupportedLocale = (userLocale: string) => {
     const normalizedLocale = userLocale.toLowerCase();
 
-    if (localeMessages[normalizedLocale]) {
+    if (availableLocales.includes(normalizedLocale)) {
         return normalizedLocale;
     }
 
     const mainLanguage = normalizedLocale.split('-')[0];
-    const mainLocale = Object.keys(localeMessages).find(locale => locale.startsWith(mainLanguage));
+    const mainLocale = availableLocales.find(locale => locale.startsWith(mainLanguage));
     if (mainLocale) {
         return mainLocale;
     }


### PR DESCRIPTION
Partially fixes #525. The changes dynamically import the language. The current method loads the language when the application is ready to display the ui. With the new approach that is too late to start downloading the language js file. Thats why i call the method in `initClientApp()`.

This improves performance, but further optimization is possible. Currently, my changes don't affect the existing `dynamicActivationLocale()` call because I'm unsure of the impact of `setLoaded()`. We're also downloading a large index.js file, which then triggers numerous imports. This forces the browser to wait for the initial file before discovering and requesting other necessary files, such as the language file. 
To address this, we should flatten the dependency structure. Instead of a single `<script>` tag in `index.html`, we should have multiple. For example, since the browser sends preferred languages in its headers, we could handle language lookup server-side, eliminating the need to download JavaScript for this purpose and then import a language file in the browser.

You can modify the changes as you like. The key part is 
``
const module = (await import(`./locales/${locale}.po`));
i18n.load(locale, module.messages);
``


## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
