### PR TITLE
Slightly improve perceived performance on EventHomepage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,7 +56,7 @@ export const App: FC<
                     width: "100vw",
                     height: "100vh",
                     position: "fixed",
-                    background: "#ffffff",
+                    background: "var(--ssr-loader-background, #fff)",
                     zIndex: 1000,
                     display: isLoadedOnBrowser ? "none" : "block",
                 }}

--- a/frontend/src/components/layouts/EventHomepage/index.tsx
+++ b/frontend/src/components/layouts/EventHomepage/index.tsx
@@ -52,6 +52,13 @@ const EventHomepage = ({colors, continueButtonText, backgroundType, ...loaderDat
 
     return (
         <div style={styleOverrides} key={`${event.id}`}>
+            <style>
+                {`
+                :root {
+                    --ssr-loader-background: ${styleOverrides["--homepage-body-background-color"]};
+                }
+                `}
+            </style>
             {event && <EventDocumentHead event={event}/>}
             {(coverImage && backgroundType === 'MIRROR_COVER_IMAGE') && (
                 <div


### PR DESCRIPTION
The app uses a white screen called the ssr-loader to hide the page until it finished loading it. The user can customize tha body background-color of the event homepage.
Every page starts white while the browser downloads the html and the render blocking css files. After that the ssr-loader can be displayed. which is also white. The user does not see any progess until all js is loaded and the ssr-loader gets removed. The new change introduce an intermediate step. The page changes from white to the body background-color. If we humans see progress like a progress bar or the background-color change, the waiting time feels shorter.

This does not improves the measured performance. Ideally the page would be entirely server-side rendered, no javascript would download more css and no ssr-loader would be used.

It uses a simple css varaible with white as a fallback if the variable is not set.

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
