### PR TITLE
Fix application fee amount handling

### DIFF
--- a/backend/app/Services/Domain/Payment/Stripe/EventHandlers/PaymentIntentSucceededHandler.php
+++ b/backend/app/Services/Domain/Payment/Stripe/EventHandlers/PaymentIntentSucceededHandler.php
@@ -233,7 +233,7 @@ class PaymentIntentSucceededHandler
     {
         $this->orderApplicationFeeService->createOrderApplicationFee(
             orderId: $updatedOrder->getId(),
-            applicationFeeAmountMinorUnit: $paymentIntent->application_fee_amount,
+            applicationFeeAmountMinorUnit: $paymentIntent->application_fee_amount ?? 0,
             orderApplicationFeeStatus: OrderApplicationFeeStatus::PAID,
             paymentMethod: PaymentProviders::STRIPE,
             currency: $updatedOrder->getCurrency(),


### PR DESCRIPTION
## Summary

This PR ensures that the `application_fee_amount` value from Stripe's `PaymentIntent` always defaults to `0` if it is not set. This prevents potential issues with null values and guarantees consistent handling of application fees throughout the payment processing workflow.

## Details

- Used the null coalescing operator (`?? 0`) when accessing `$paymentIntent->application_fee_amount` in all relevant places.
- This ensures that if Stripe does not provide an `application_fee_amount`, the system will safely use `0` as the default.
- Improves reliability and prevents errors related to missing or null fee amounts.

## Motivation

This change improves the robustness of the payment handling logic by ensuring that all calculations and records involving the application fee are based on a valid integer value, even if Stripe omits the field.

## Checklist

- [x] Code follows project standards
- [x] All usages of `application_fee_amount` are safely defaulted to `0`
- [x] Tested to ensure no errors occur when the field is missing
