### PR TITLE
Add Laravel queue worker to startup

### DIFF
--- a/docker/all-in-one/.env
+++ b/docker/all-in-one/.env
@@ -13,7 +13,7 @@ VITE_STRIPE_PUBLISHABLE_KEY=pk_test_123456789
 # Please refer to the documentation for more information on how to configure these values
 # https://hi.events/docs/getting-started/deploying
 LOG_CHANNEL=stderr
-QUEUE_CONNECTION=sync
+QUEUE_CONNECTION=redis
 
 # Application settings
 APP_CDN_URL=http://localhost:8123/storage
@@ -45,3 +45,8 @@ DATABASE_URL=postgresql://postgres:secret@postgres:5432/hi-events
 STRIPE_PUBLIC_KEY=pk_test_123456789
 STRIPE_SECRET_KEY=sk_test_123456789
 STRIPE_WEBHOOK_SECRET=whsec_test_123456789
+
+# Redis settings
+REDIS_HOST=redis
+REDIS_PASSWORD=
+REDIS_PORT=6379

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -50,7 +50,7 @@ JWT_SECRET=your_generated_jwt_secret
 ### Step 4: Start the Docker Containers
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Step 5: Create an Account

--- a/docker/all-in-one/docker-compose.yml
+++ b/docker/all-in-one/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     container_name: all-in-one
     ports:
       - "8123:80"
+    networks:
+      - hi-events-network
     environment:
       - VITE_FRONTEND_URL=${VITE_FRONTEND_URL}
       - VITE_API_URL_CLIENT=${VITE_API_URL_CLIENT}
@@ -35,6 +37,9 @@ services:
       - FILESYSTEM_PUBLIC_DISK=${FILESYSTEM_PUBLIC_DISK}
       - FILESYSTEM_PRIVATE_DISK=${FILESYSTEM_PRIVATE_DISK}
       - DATABASE_URL=postgresql://postgres:secret@postgres:5432/hi-events
+      - REDIS_HOST=redis
+      - REDIS_PASSWORD=
+      - REDIS_PORT=6379
       - STRIPE_PUBLIC_KEY=${STRIPE_PUBLIC_KEY}
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
@@ -42,10 +47,29 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  redis:
+    image: redis:latest
+    container_name: redis
+    networks:
+      - hi-events-network
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "6379:6379"
+    volumes:
+      - redisdata:/data
 
   postgres:
     image: postgres:latest
     container_name: postgres
+    networks:
+      - hi-events-network
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s
@@ -58,5 +82,12 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+networks:
+  hi-events-network:
+    driver: bridge
+
 volumes:
   pgdata:
+    driver: local
+  redisdata:
+    driver: local

--- a/docker/all-in-one/docker-compose.yml
+++ b/docker/all-in-one/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - STRIPE_PUBLIC_KEY=${STRIPE_PUBLIC_KEY}
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+      - WEBHOOK_QUEUE_NAME=webhook-queue
 
     depends_on:
       postgres:

--- a/docker/all-in-one/supervisor/supervisord.conf
+++ b/docker/all-in-one/supervisor/supervisord.conf
@@ -37,7 +37,7 @@ stderr_logfile_maxbytes = 0
 environment=NODE_ENV="production",VITE_API_URL_CLIENT="%(ENV_VITE_API_URL_CLIENT)s",VITE_API_URL_SERVER="http://localhost:80/api",VITE_FRONTEND_URL="%(ENV_VITE_FRONTEND_URL)s",VITE_STRIPE_PUBLISHABLE_KEY="%(ENV_VITE_STRIPE_PUBLISHABLE_KEY)s"
 
 [program:laravel-queue-worker]
-command=php /app/backend/artisan queue:work --sleep=3 --tries=3 --timeout=60
+command=php /app/backend/artisan queue:work --queue=default,webhook-queue --sleep=3 --tries=3 --timeout=60
 autostart=true
 autorestart=true
 user=www-data

--- a/docker/all-in-one/supervisor/supervisord.conf
+++ b/docker/all-in-one/supervisor/supervisord.conf
@@ -35,3 +35,14 @@ redirect_stderr=true
 stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
 environment=NODE_ENV="production",VITE_API_URL_CLIENT="%(ENV_VITE_API_URL_CLIENT)s",VITE_API_URL_SERVER="http://localhost:80/api",VITE_FRONTEND_URL="%(ENV_VITE_FRONTEND_URL)s",VITE_STRIPE_PUBLISHABLE_KEY="%(ENV_VITE_STRIPE_PUBLISHABLE_KEY)s"
+
+[program:laravel-queue-worker]
+command=php /app/backend/artisan queue:work --sleep=3 --tries=3 --timeout=60
+autostart=true
+autorestart=true
+user=www-data
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+redirect_stderr=true
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
This pull request adds a new program configuration to the `supervisord.conf` to ensure that `php artisan queue:work` is ran automatically on startup. The configuration ensures proper logging and automatic restart behavior for the queue worker process. Fixes #270, #506.

### Added Laravel queue worker configuration:

* [`docker/all-in-one/supervisor/supervisord.conf`](diffhunk://#diff-9fe669a8ee4481899240c861c9b8288609e1d4efddb88d168facca9f8640d161R38-R48): Added a `[program:laravel-queue-worker]` section to run Laravel's queue worker with specific parameters, including `autostart`, `autorestart`, logging to standard output and error, and setting log file size limits to zero for unlimited logging.

