### PR TITLE
Use Laravel Filesystem URL Generator for Images

### DIFF
--- a/backend/app/Helper/Url.php
+++ b/backend/app/Helper/Url.php
@@ -29,9 +29,26 @@ class Url
         return self::addQueryParamsToUrl($queryParams, $url);
     }
 
+    /**
+    * Generates a CDN URL for the given path if a CDN URL is configured.
+    * Falls back to generating a URL using the specified or default filesystem disk.
+    *
+    * @param string $path The relative path to the asset.
+    * @return string The fully qualified URL to the asset, either via CDN or storage disk.
+    */
     public static function getCdnUrl(string $path): string
     {
-        return config('app.cnd_url') . '/' . $path;
+        // Fetch the CDN URL from environment variables
+        // Checking against the env variable instead of config() as config falls back to the default value
+        // and we want to ensure that if the env variable is not set, we do not use a default value.
+        $envCDNUrl = env('CDN_URL'); 
+
+        if ($envCDNUrl) {
+            return  $envCDNUrl . '/' . $path;
+         }
+
+        $disk = config('filesystems.public', 'public');
+        return app('filesystem')->disk($disk)->url($path);
     }
 
     private static function addQueryParamsToUrl(array $queryParams, mixed $url): mixed

--- a/backend/app/Helper/Url.php
+++ b/backend/app/Helper/Url.php
@@ -41,7 +41,7 @@ class Url
         // Fetch the CDN URL from environment variables
         // Checking against the env variable instead of config() as config falls back to the default value
         // and we want to ensure that if the env variable is not set, we do not use a default value.
-        $envCDNUrl = env('CDN_URL'); 
+        $envCDNUrl = env('APP_CDN_URL'); 
 
         if ($envCDNUrl) {
             return  $envCDNUrl . '/' . $path;


### PR DESCRIPTION
Updating the `getCdnUrl` helper to fall back to generating a URL using the filesystem disk if the `CDN_URL` environment variable is not set. This allows us to still use S3 resource links if a CDN Url is not in place. Fixes #616.

#### Enhancements to image url generation:
* `backend/app/Helper/Url.php`: Updated the `getCdnUrl` method to:
  - Check for the `CDN_URL` environment variable and use this if it is set.
  - Fall back to generating a URL using the specified or default filesystem disk (`public`) if the CDN URL is not configured. see: https://laravel.com/docs/11.x/filesystem#file-urls

#### Notes
I have discovered a typo `'cnd_url'` in `app.php` which has not been resolved in this PR.
