### PR TITLE
Fix: Allow empty strings for event settings maps_url

### DIFF
--- a/backend/app/Services/Application/Handlers/EventSettings/PartialUpdateEventSettingsHandler.php
+++ b/backend/app/Services/Application/Handlers/EventSettings/PartialUpdateEventSettingsHandler.php
@@ -65,7 +65,9 @@ readonly class PartialUpdateEventSettingsHandler
 
                 'order_timeout_in_minutes' => $eventSettingsDTO->settings['order_timeout_in_minutes'] ?? $existingSettings->getOrderTimeoutInMinutes(),
                 'website_url' => $eventSettingsDTO->settings['website_url'] ?? $existingSettings->getWebsiteUrl(),
-                'maps_url' => $eventSettingsDTO->settings['maps_url'] ?? $existingSettings->getMapsUrl(),
+                'maps_url' => array_key_exists('maps_url', $eventSettingsDTO->settings)
+                    ? $eventSettingsDTO->settings['maps_url']
+                    : $existingSettings->getMapsUrl(),
                 'location_details' => $locationDetails,
                 'is_online_event' => $eventSettingsDTO->settings['is_online_event'] ?? $existingSettings->getIsOnlineEvent(),
                 'online_event_connection_details' => array_key_exists('online_event_connection_details', $eventSettingsDTO->settings)


### PR DESCRIPTION
# Fix: Allow empty strings for event settings maps_url

## Problem
Users were unable to save empty values for the maps URL field in event settings. When attempting to clear an existing maps URL, the system would ignore the empty value and revert to the previously saved URL upon save.

Fixes [🐛 Cannot save empty maps URL in event settings #624](https://github.com/HiEventsDev/Hi.Events/issues/624)

## Cause
The issue occurred in the `PartialUpdateEventSettingsHandler.php` file where the `maps_url` field was being handled using the null coalescing operator (`??`):

```php
'maps_url' => $eventSettingsDTO->settings['maps_url'] ?? $existingSettings->getMapsUrl(),
```

In PHP, this operator treats empty strings as falsy values, causing the system to fall back to the existing value when users attempted to save an empty string.

## Solution
Updated the code to use `array_key_exists()` instead of the null coalescing operator, matching the pattern already used for other text fields in the same handler:

```php
'maps_url' => array_key_exists('maps_url', $eventSettingsDTO->settings)
    ? $eventSettingsDTO->settings['maps_url']
    : $existingSettings->getMapsUrl(),
```

This approach checks if the key exists in the settings array (regardless of its value), allowing empty strings to be properly saved.

## Impact
Event organizers can now:
- Clear previously set maps URLs when needed
- Explicitly save empty values for the maps URL field
- Have a consistent user experience across all text fields in the event settings

This change improves the user experience for event organizers who need to manage location settings for their events.

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
