### PR TITLE
fix: get the script by id instead of depending on document.currentScr…

### DIFF
--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -5,10 +5,11 @@
     const loadWidget = () => {
         window.hiEventWidgetLoaded = true;
 
-        let scriptOrigin;
+       let scriptOrigin;
         try {
-            const scriptURL = document.currentScript.src;
-            scriptOrigin = new URL(scriptURL).origin;
+            const script = document.getElementById('hievent-widget-script');
+            if (!script || !script.src) throw new Error('HiEvent widget error: Invalid script URL');
+            scriptOrigin = new URL(script.src).origin;
         } catch (e) {
             console.error('HiEvent widget error: Invalid script URL');
             return;

--- a/frontend/src/components/common/WidgetEditor/index.tsx
+++ b/frontend/src/components/common/WidgetEditor/index.tsx
@@ -1,18 +1,18 @@
-import classes from './WidgetEditor.module.scss';
+import { t, Trans } from "@lingui/macro";
+import { ColorInput, Group, NumberInput, Switch, Tabs, Textarea, TextInput } from "@mantine/core";
+import { matches, useForm } from "@mantine/form";
+import { IconInfoCircle } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router";
+import { useGetEvent } from "../../../queries/useGetEvent.ts";
+import { useGetEventSettings } from "../../../queries/useGetEventSettings.ts";
+import { Event } from '../../../types.ts';
 import SelectProducts from "../../routes/product-widget/SelectProducts";
-import {ColorInput, Group, NumberInput, Switch, Tabs, Textarea, TextInput} from "@mantine/core";
-import {t, Trans} from "@lingui/macro";
-import {matches, useForm} from "@mantine/form";
-import {useEffect, useState} from "react";
-import {CopyButton} from "../CopyButton";
-import {useParams} from "react-router";
-import {IconInfoCircle} from "@tabler/icons-react";
-import {useGetEventSettings} from "../../../queries/useGetEventSettings.ts";
-import {Popover} from "../Popover";
-import {LoadingMask} from '../LoadingMask';
-import {Event} from '../../../types.ts';
-import {useGetEvent} from "../../../queries/useGetEvent.ts";
-import {Card} from "../Card";
+import { Card } from "../Card";
+import { CopyButton } from "../CopyButton";
+import { LoadingMask } from '../LoadingMask';
+import { Popover } from "../Popover";
+import classes from './WidgetEditor.module.scss';
 
 export const WidgetEditor = () => {
     const {eventId} = useParams();
@@ -46,7 +46,7 @@ export const WidgetEditor = () => {
     const [reactUsageCode, setReactUsageCode] = useState<string>("");
     const currentLocation = typeof window !== "undefined" ? window?.location : undefined;
     const embedUrl = `${currentLocation?.protocol}//${currentLocation?.host}/widget.js`;
-    const embedScript = `<script async src="${embedUrl}"></script>`;
+    const embedScript = `<script id="hievent-widget-script" async src="${embedUrl}"></script>`;
 
     useEffect(() => {
         setHtmlEmbedCode(

--- a/frontend/src/embed/widget.js
+++ b/frontend/src/embed/widget.js
@@ -5,10 +5,11 @@
     const loadWidget = () => {
         window.hiEventWidgetLoaded = true;
 
-        let scriptOrigin;
+       let scriptOrigin;
         try {
-            const scriptURL = scriptElement.src;
-            scriptOrigin = new URL(scriptURL).origin;
+            const script = document.getElementById('hievent-widget-script');
+            if (!script || !script.src) throw new Error('HiEvent widget error: Invalid script URL');
+            scriptOrigin = new URL(script.src).origin;
         } catch (e) {
             console.error('HiEvent widget error: Invalid script URL');
             return;


### PR DESCRIPTION
Refactor the current method for getting the current script to make it more reliable. Fixes #676.

### Improvements to widget script handling:
* Updated the widget script identification logic to use `document.getElementById('hievent-widget-script')` instead of relying on `document.currentScript`, ensuring the script is explicitly located and validated. This change was applied in both `frontend/public/widget.js` and `frontend/src/embed/widget.js` for consistency. [[1]](diffhunk://#diff-f27aa7db713286ef73cfb8a2d8e4d52ce3c7c140b6892fd878fdda588b398952L10-R12) [[2]](diffhunk://#diff-a89719d971967baf7ee6fb952636197115dcb47640fc8680878b5386d3f268d2L10-R12)
* Modified the `embedScript` in the `WidgetEditor` component to include the `id="hievent-widget-script"` attribute, aligning it with the updated script identification logic.

### (sorry for the import re-organise):
*  imports in `frontend/src/components/common/WidgetEditor/index.tsx` re-ordered. I opened Hi.Events in the wrong IDE Workspace (sorry!).