### PR TITLE
Update de.po - Consistent and semantic translation wording: Menge vs. Betrag

### DIFF
--- a/frontend/src/locales/de.po
+++ b/frontend/src/locales/de.po
@@ -571,7 +571,7 @@ msgstr "Erstaunlich, Ereignis, Schlüsselwörter..."
 #: src/components/forms/TaxAndFeeForm/index.tsx:71
 #: src/components/routes/product-widget/SelectProducts/Prices/Tiered/index.tsx:36
 msgid "Amount"
-msgstr "Menge"
+msgstr "Betrag"
 
 #: src/components/modals/CreateAttendeeModal/index.tsx:176
 msgid "Amount paid ({0})"


### PR DESCRIPTION
The translation ‘Menge’ for “amount” does not fit semantically in this context; everywhere else, the term ‘Betrag’ is used, which should be consistent and leads to less confusion.

I have read the CLA Document and I hereby sign the CLA