### PR TITLE
Pin postgres version 17 to fix startup error with postgres >=18

### DIFF
--- a/docker/all-in-one/docker-compose.yml
+++ b/docker/all-in-one/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - redisdata:/data
 
   postgres:
-    image: postgres:latest
+    image: postgres:17
     container_name: postgres
     networks:
       - hi-events-network


### PR DESCRIPTION
Postgres >=18 changed the volume mount and will no longer start with this configuration.

See: https://github.com/docker-library/postgres/pull/1259

Thank you for creating a PR! We appreciate your contribution to Hi.Events.

To make the process as smooth as possible, please ensure you've read the [contributing guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md) before proceeding.

Please include a summary of the changes and the issue being fixed or the feature being added. The more detail, the better!

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
