### PR TITLE
Fix missing "Complete Order" button on checkout page

### DIFF
--- a/frontend/src/components/layouts/Checkout/Checkout.module.scss
+++ b/frontend/src/components/layouts/Checkout/Checkout.module.scss
@@ -5,7 +5,10 @@ $font-body:  'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sa
 
 .container {
   display: flex;
+  // Use dvh (dynamic viewport height) with fallback for older browsers
+  // This fixes iOS Safari where 100vh includes the address bar height
   min-height: 100vh;
+  min-height: 100dvh;
   font-family: $font-body;
 
   // CSS variables are set by CheckoutThemeProvider via MantineProvider cssVariablesResolver

--- a/frontend/src/components/layouts/Checkout/CheckoutContent/CheckoutContent.module.scss
+++ b/frontend/src/components/layouts/Checkout/CheckoutContent/CheckoutContent.module.scss
@@ -2,15 +2,22 @@
 
 .main {
   position: relative;
+  // Use dvh (dynamic viewport height) with fallback for older browsers
+  // This fixes iOS Safari where 100vh includes the address bar height,
+  // causing content (like the Complete Order button) to be cut off
   min-height: calc(100vh - 60px);
+  min-height: calc(100dvh - 60px);
   height: auto;
   overflow-y: auto;
   padding: 20px 60px 40px;
+  // Ensure content is visible above iOS safe area
+  padding-bottom: max(40px, env(safe-area-inset-bottom, 40px));
 
   @include mixins.scrollbar();
 
   @include mixins.respond-below(md) {
     padding: 20px 20px 40px;
+    padding-bottom: max(40px, env(safe-area-inset-bottom, 40px));
   }
 
   .innerContainer {


### PR DESCRIPTION
Fixes an issue where the **"Complete Order"** button could be hidden on the checkout page due to viewport height and safe-area behavior.

## Root Cause
The checkout container relied on `100vh`, which includes browser UI on iOS Safari and some desktop layouts, causing content near the bottom (including the button) to be cut off.

## Solution
- Replaced `100vh` with `100dvh` and added a `100vh` fallback
- Added `env(safe-area-inset-bottom)` padding to ensure visibility on iOS devices with notches
- Applied changes consistently across desktop and mobile breakpoints

## How to Test
1. Open checkout page
2. Proceed to ticket checkout
3. Scroll to the bottom
4. Confirm the **Complete Order** button is visible and accessible

## Related Issue
Closes #887

