### PR TITLE
Feature: External Registration URL Support (#1024)

### DIFF
--- a/backend/app/DomainObjects/Generated/EventDailyStatisticDomainObjectAbstract.php
+++ b/backend/app/DomainObjects/Generated/EventDailyStatisticDomainObjectAbstract.php
@@ -27,6 +27,7 @@ abstract class EventDailyStatisticDomainObjectAbstract extends \HiEvents\DomainO
     final public const TOTAL_VIEWS = 'total_views';
     final public const ATTENDEES_REGISTERED = 'attendees_registered';
     final public const ORDERS_CANCELLED = 'orders_cancelled';
+    final public const EXTERNAL_REGISTRATION_CLICKS = 'external_registration_clicks';
 
     protected int $id;
     protected int $event_id;
@@ -45,6 +46,7 @@ abstract class EventDailyStatisticDomainObjectAbstract extends \HiEvents\DomainO
     protected int $total_views = 0;
     protected int $attendees_registered = 0;
     protected int $orders_cancelled = 0;
+    protected int $external_registration_clicks = 0;
 
     public function toArray(): array
     {
@@ -66,6 +68,7 @@ abstract class EventDailyStatisticDomainObjectAbstract extends \HiEvents\DomainO
                     'total_views' => $this->total_views ?? null,
                     'attendees_registered' => $this->attendees_registered ?? null,
                     'orders_cancelled' => $this->orders_cancelled ?? null,
+                    'external_registration_clicks' => $this->external_registration_clicks ?? null,
                 ];
     }
 
@@ -254,5 +257,16 @@ abstract class EventDailyStatisticDomainObjectAbstract extends \HiEvents\DomainO
     public function getOrdersCancelled(): int
     {
         return $this->orders_cancelled;
+    }
+
+    public function setExternalRegistrationClicks(int $external_registration_clicks): self
+    {
+        $this->external_registration_clicks = $external_registration_clicks;
+        return $this;
+    }
+
+    public function getExternalRegistrationClicks(): int
+    {
+        return $this->external_registration_clicks;
     }
 }

--- a/backend/app/DomainObjects/Generated/EventSettingDomainObjectAbstract.php
+++ b/backend/app/DomainObjects/Generated/EventSettingDomainObjectAbstract.php
@@ -64,6 +64,11 @@ abstract class EventSettingDomainObjectAbstract extends \HiEvents\DomainObjects\
     final public const HOMEPAGE_THEME_SETTINGS = 'homepage_theme_settings';
     final public const PASS_PLATFORM_FEE_TO_BUYER = 'pass_platform_fee_to_buyer';
     final public const ALLOW_ATTENDEE_SELF_EDIT = 'allow_attendee_self_edit';
+    final public const IS_EXTERNAL_REGISTRATION = 'is_external_registration';
+    final public const EXTERNAL_REGISTRATION_URL = 'external_registration_url';
+    final public const EXTERNAL_REGISTRATION_BUTTON_TEXT = 'external_registration_button_text';
+    final public const EXTERNAL_REGISTRATION_MESSAGE = 'external_registration_message';
+    final public const EXTERNAL_REGISTRATION_HOST = 'external_registration_host';
 
     protected int $id;
     protected int $event_id;
@@ -119,6 +124,11 @@ abstract class EventSettingDomainObjectAbstract extends \HiEvents\DomainObjects\
     protected array|string|null $homepage_theme_settings = null;
     protected bool $pass_platform_fee_to_buyer = false;
     protected bool $allow_attendee_self_edit = true;
+    protected bool $is_external_registration = false;
+    protected ?string $external_registration_url = null;
+    protected ?string $external_registration_button_text = null;
+    protected ?string $external_registration_message = null;
+    protected ?string $external_registration_host = null;
 
     public function toArray(): array
     {
@@ -177,6 +187,11 @@ abstract class EventSettingDomainObjectAbstract extends \HiEvents\DomainObjects\
                     'homepage_theme_settings' => $this->homepage_theme_settings ?? null,
                     'pass_platform_fee_to_buyer' => $this->pass_platform_fee_to_buyer ?? null,
                     'allow_attendee_self_edit' => $this->allow_attendee_self_edit ?? null,
+                    'is_external_registration' => $this->is_external_registration ?? null,
+                    'external_registration_url' => $this->external_registration_url ?? null,
+                    'external_registration_button_text' => $this->external_registration_button_text ?? null,
+                    'external_registration_message' => $this->external_registration_message ?? null,
+                    'external_registration_host' => $this->external_registration_host ?? null,
                 ];
     }
 
@@ -773,5 +788,60 @@ abstract class EventSettingDomainObjectAbstract extends \HiEvents\DomainObjects\
     public function getAllowAttendeeSelfEdit(): bool
     {
         return $this->allow_attendee_self_edit;
+    }
+
+    public function setIsExternalRegistration(bool $is_external_registration): self
+    {
+        $this->is_external_registration = $is_external_registration;
+        return $this;
+    }
+
+    public function getIsExternalRegistration(): bool
+    {
+        return $this->is_external_registration;
+    }
+
+    public function setExternalRegistrationUrl(?string $external_registration_url): self
+    {
+        $this->external_registration_url = $external_registration_url;
+        return $this;
+    }
+
+    public function getExternalRegistrationUrl(): ?string
+    {
+        return $this->external_registration_url;
+    }
+
+    public function setExternalRegistrationButtonText(?string $external_registration_button_text): self
+    {
+        $this->external_registration_button_text = $external_registration_button_text;
+        return $this;
+    }
+
+    public function getExternalRegistrationButtonText(): ?string
+    {
+        return $this->external_registration_button_text;
+    }
+
+    public function setExternalRegistrationMessage(?string $external_registration_message): self
+    {
+        $this->external_registration_message = $external_registration_message;
+        return $this;
+    }
+
+    public function getExternalRegistrationMessage(): ?string
+    {
+        return $this->external_registration_message;
+    }
+
+    public function setExternalRegistrationHost(?string $external_registration_host): self
+    {
+        $this->external_registration_host = $external_registration_host;
+        return $this;
+    }
+
+    public function getExternalRegistrationHost(): ?string
+    {
+        return $this->external_registration_host;
     }
 }

--- a/backend/app/DomainObjects/Generated/EventStatisticDomainObjectAbstract.php
+++ b/backend/app/DomainObjects/Generated/EventStatisticDomainObjectAbstract.php
@@ -27,6 +27,7 @@ abstract class EventStatisticDomainObjectAbstract extends \HiEvents\DomainObject
     final public const TOTAL_REFUNDED = 'total_refunded';
     final public const ATTENDEES_REGISTERED = 'attendees_registered';
     final public const ORDERS_CANCELLED = 'orders_cancelled';
+    final public const EXTERNAL_REGISTRATION_CLICKS = 'external_registration_clicks';
 
     protected int $id;
     protected int $event_id;
@@ -45,6 +46,7 @@ abstract class EventStatisticDomainObjectAbstract extends \HiEvents\DomainObject
     protected float $total_refunded = 0.0;
     protected int $attendees_registered = 0;
     protected int $orders_cancelled = 0;
+    protected int $external_registration_clicks = 0;
 
     public function toArray(): array
     {
@@ -66,6 +68,7 @@ abstract class EventStatisticDomainObjectAbstract extends \HiEvents\DomainObject
                     'total_refunded' => $this->total_refunded ?? null,
                     'attendees_registered' => $this->attendees_registered ?? null,
                     'orders_cancelled' => $this->orders_cancelled ?? null,
+                    'external_registration_clicks' => $this->external_registration_clicks ?? null,
                 ];
     }
 
@@ -254,5 +257,16 @@ abstract class EventStatisticDomainObjectAbstract extends \HiEvents\DomainObject
     public function getOrdersCancelled(): int
     {
         return $this->orders_cancelled;
+    }
+
+    public function setExternalRegistrationClicks(int $external_registration_clicks): self
+    {
+        $this->external_registration_clicks = $external_registration_clicks;
+        return $this;
+    }
+
+    public function getExternalRegistrationClicks(): int
+    {
+        return $this->external_registration_clicks;
     }
 }

--- a/backend/app/Http/Actions/Events/TrackExternalRegistrationClickAction.php
+++ b/backend/app/Http/Actions/Events/TrackExternalRegistrationClickAction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace HiEvents\Http\Actions\Events;
+
+use HiEvents\Http\Actions\BaseAction;
+use HiEvents\Services\Domain\EventStatistics\EventStatisticsIncrementService;
+use Illuminate\Http\JsonResponse;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+class TrackExternalRegistrationClickAction extends BaseAction
+{
+    public function __construct(
+        private readonly EventStatisticsIncrementService $eventStatisticsIncrementService,
+        private readonly LoggerInterface                 $logger,
+    )
+    {
+    }
+
+    public function __invoke(int $eventId): JsonResponse
+    {
+        try {
+            $this->eventStatisticsIncrementService->incrementExternalRegistrationClick($eventId);
+
+            return $this->successResponse();
+        } catch (Throwable $e) {
+            // Silent failure - log error but don't block user
+            $this->logger->error(
+                'Failed to track external registration click',
+                [
+                    'event_id' => $eventId,
+                    'exception' => $e::class,
+                    'message' => $e->getMessage(),
+                ]
+            );
+
+            // Still return success to not block the user's navigation
+            return $this->successResponse();
+        }
+    }
+}

--- a/backend/app/Http/Request/EventSettings/UpdateEventSettingsRequest.php
+++ b/backend/app/Http/Request/EventSettings/UpdateEventSettingsRequest.php
@@ -101,6 +101,31 @@ class UpdateEventSettingsRequest extends BaseRequest
 
             // Self-service settings
             'allow_attendee_self_edit' => ['boolean'],
+
+            // External registration settings
+            'is_external_registration' => ['boolean'],
+            'external_registration_url' => [
+                'nullable',
+                'url',
+                'max:500',
+                Rule::requiredIf(fn() => $this->input('is_external_registration') === true)
+            ],
+            'external_registration_button_text' => [
+                'nullable',
+                'string',
+                'max:100',
+                Rule::requiredIf(fn() => $this->input('is_external_registration') === true)
+            ],
+            'external_registration_message' => [
+                'nullable',
+                'string',
+                'max:500'
+            ],
+            'external_registration_host' => [
+                'nullable',
+                'string',
+                'max:255'
+            ],
         ];
     }
 
@@ -143,6 +168,13 @@ class UpdateEventSettingsRequest extends BaseRequest
             'homepage_theme_settings.background' => $colorMessage,
             'homepage_theme_settings.mode.in' => __('The mode must be light or dark.'),
             'homepage_theme_settings.background_type.in' => __('The background type must be COLOR or MIRROR_COVER_IMAGE.'),
+
+            // External registration messages
+            'external_registration_url.required' => __('The external registration URL is required when external registration is enabled.'),
+            'external_registration_url.url' => __('The external registration URL must be a valid URL.'),
+            'external_registration_url.max' => __('The external registration URL may not be greater than 500 characters.'),
+            'external_registration_button_text.required' => __('The button text is required when external registration is enabled.'),
+            'external_registration_button_text.max' => __('The button text may not be greater than 100 characters.'),
         ];
     }
 }

--- a/backend/app/Resources/Event/EventSettingsResource.php
+++ b/backend/app/Resources/Event/EventSettingsResource.php
@@ -79,6 +79,13 @@ class EventSettingsResource extends JsonResource
 
             // Self-service settings
             'allow_attendee_self_edit' => $this->getAllowAttendeeSelfEdit(),
+
+            // External registration settings
+            'is_external_registration' => $this->getIsExternalRegistration(),
+            'external_registration_url' => $this->getExternalRegistrationUrl(),
+            'external_registration_button_text' => $this->getExternalRegistrationButtonText(),
+            'external_registration_message' => $this->getExternalRegistrationMessage(),
+            'external_registration_host' => $this->getExternalRegistrationHost(),
         ];
     }
 }

--- a/backend/app/Resources/Event/EventSettingsResourcePublic.php
+++ b/backend/app/Resources/Event/EventSettingsResourcePublic.php
@@ -85,6 +85,13 @@ class EventSettingsResourcePublic extends JsonResource
 
             // Self-service settings
             'allow_attendee_self_edit' => $this->getAllowAttendeeSelfEdit(),
+
+            // External registration settings
+            'is_external_registration' => $this->getIsExternalRegistration(),
+            'external_registration_url' => $this->getExternalRegistrationUrl(),
+            'external_registration_button_text' => $this->getExternalRegistrationButtonText(),
+            'external_registration_message' => $this->getExternalRegistrationMessage(),
+            'external_registration_host' => $this->getExternalRegistrationHost(),
         ];
     }
 }

--- a/backend/app/Resources/Event/EventStatisticsResource.php
+++ b/backend/app/Resources/Event/EventStatisticsResource.php
@@ -23,6 +23,7 @@ class EventStatisticsResource extends JsonResource
             'products_sold' => $this->getProductsSold(),
             'attendees_registered' => $this->getAttendeesRegistered(),
             'total_refunded' => $this->getTotalRefunded(),
+            'external_registration_clicks' => $this->getExternalRegistrationClicks(),
         ];
     }
 }

--- a/backend/app/Services/Application/Handlers/Event/DTO/EventStatsResponseDTO.php
+++ b/backend/app/Services/Application/Handlers/Event/DTO/EventStatsResponseDTO.php
@@ -25,6 +25,7 @@ class EventStatsResponseDTO extends BaseDTO
         public float                        $total_tax,
         public float                        $total_views,
         public float                        $total_refunded,
+        public int                          $total_external_registration_clicks,
     )
     {
     }

--- a/backend/app/Services/Application/Handlers/EventSettings/DTO/UpdateEventSettingsDTO.php
+++ b/backend/app/Services/Application/Handlers/EventSettings/DTO/UpdateEventSettingsDTO.php
@@ -83,6 +83,13 @@ class UpdateEventSettingsDTO extends BaseDTO
 
         // Self-service settings
         public readonly bool                    $allow_attendee_self_edit = false,
+
+        // External registration settings
+        public readonly bool                    $is_external_registration = false,
+        public readonly ?string                 $external_registration_url = null,
+        public readonly ?string                 $external_registration_button_text = null,
+        public readonly ?string                 $external_registration_message = null,
+        public readonly ?string                 $external_registration_host = null,
     )
     {
     }
@@ -165,6 +172,13 @@ class UpdateEventSettingsDTO extends BaseDTO
 
             // Self-service defaults
             allow_attendee_self_edit: false,
+
+            // External registration defaults
+            is_external_registration: false,
+            external_registration_url: null,
+            external_registration_button_text: null,
+            external_registration_message: null,
+            external_registration_host: null,
         );
     }
 }

--- a/backend/app/Services/Application/Handlers/EventSettings/PartialUpdateEventSettingsHandler.php
+++ b/backend/app/Services/Application/Handlers/EventSettings/PartialUpdateEventSettingsHandler.php
@@ -137,6 +137,21 @@ class PartialUpdateEventSettingsHandler
 
                 // Self-service settings
                 'allow_attendee_self_edit' => $eventSettingsDTO->settings['allow_attendee_self_edit'] ?? $existingSettings->getAllowAttendeeSelfEdit(),
+
+                // External registration settings
+                'is_external_registration' => $eventSettingsDTO->settings['is_external_registration'] ?? $existingSettings->getIsExternalRegistration(),
+                'external_registration_url' => array_key_exists('external_registration_url', $eventSettingsDTO->settings)
+                    ? $eventSettingsDTO->settings['external_registration_url']
+                    : $existingSettings->getExternalRegistrationUrl(),
+                'external_registration_button_text' => array_key_exists('external_registration_button_text', $eventSettingsDTO->settings)
+                    ? $eventSettingsDTO->settings['external_registration_button_text']
+                    : $existingSettings->getExternalRegistrationButtonText(),
+                'external_registration_message' => array_key_exists('external_registration_message', $eventSettingsDTO->settings)
+                    ? $eventSettingsDTO->settings['external_registration_message']
+                    : $existingSettings->getExternalRegistrationMessage(),
+                'external_registration_host' => array_key_exists('external_registration_host', $eventSettingsDTO->settings)
+                    ? $eventSettingsDTO->settings['external_registration_host']
+                    : $existingSettings->getExternalRegistrationHost(),
             ]),
         );
     }

--- a/backend/app/Services/Application/Handlers/EventSettings/UpdateEventSettingsHandler.php
+++ b/backend/app/Services/Application/Handlers/EventSettings/UpdateEventSettingsHandler.php
@@ -93,7 +93,14 @@ class UpdateEventSettingsHandler
                     'homepage_theme_settings' => $settings->homepage_theme_settings,
 
                     // Self-service settings
-                    'allow_attendee_self_edit' => $settings->allow_attendee_self_edit
+                    'allow_attendee_self_edit' => $settings->allow_attendee_self_edit,
+
+                    // External registration settings
+                    'is_external_registration' => $settings->is_external_registration,
+                    'external_registration_url' => $settings->external_registration_url ? trim($settings->external_registration_url) : null,
+                    'external_registration_button_text' => $settings->external_registration_button_text ? trim($settings->external_registration_button_text) : null,
+                    'external_registration_message' => $settings->external_registration_message,
+                    'external_registration_host' => $settings->external_registration_host ? trim($settings->external_registration_host) : null,
                 ],
                 where: [
                     'event_id' => $settings->event_id,

--- a/backend/app/Services/Domain/Event/DTO/EventDailyStatsResponseDTO.php
+++ b/backend/app/Services/Domain/Event/DTO/EventDailyStatsResponseDTO.php
@@ -13,6 +13,7 @@ readonly class EventDailyStatsResponseDTO
         public int    $orders_created,
         public int    $attendees_registered,
         public float  $total_refunded,
+        public int    $external_registration_clicks,
 
     )
     {

--- a/backend/app/Services/Domain/Event/EventStatsFetchService.php
+++ b/backend/app/Services/Domain/Event/EventStatsFetchService.php
@@ -32,7 +32,8 @@ readonly class EventStatsFetchService
             SUM(es.total_fee) AS total_fees,
             SUM(es.total_views) AS total_views,
             SUM(es.total_refunded) AS total_refunded,
-            SUM(es.attendees_registered) AS attendees_registered
+            SUM(es.attendees_registered) AS attendees_registered,
+            SUM(es.external_registration_clicks) AS total_external_registration_clicks
 
         FROM event_statistics es
         WHERE es.event_id = :eventId
@@ -55,6 +56,7 @@ readonly class EventStatsFetchService
             total_tax: $totalsResult->total_tax ?? 0,
             total_views: $totalsResult->total_views ?? 0,
             total_refunded: $totalsResult->total_refunded ?? 0,
+            total_external_registration_clicks: $totalsResult->total_external_registration_clicks ?? 0,
         );
     }
 
@@ -82,7 +84,8 @@ readonly class EventStatsFetchService
               COALESCE(SUM(eds.orders_created), 0) AS orders_created,
               COALESCE(SUM(eds.products_sold), 0) AS products_sold,
               COALESCE(SUM(eds.attendees_registered), 0) AS attendees_registered,
-              COALESCE(SUM(eds.total_refunded), 0) AS total_refunded
+              COALESCE(SUM(eds.total_refunded), 0) AS total_refunded,
+              COALESCE(SUM(eds.external_registration_clicks), 0) AS external_registration_clicks
             FROM date_series ds
             LEFT JOIN event_daily_statistics eds ON ds.date = eds.date AND eds.deleted_at IS NULL AND eds.event_id = :eventId
             GROUP BY ds.date
@@ -109,6 +112,7 @@ readonly class EventStatsFetchService
                 orders_created: $result->orders_created,
                 attendees_registered: $result->attendees_registered,
                 total_refunded: $result->total_refunded,
+                external_registration_clicks: $result->external_registration_clicks,
             );
         });
     }

--- a/backend/database/migrations/2026_01_27_100000_add_external_registration_to_event_settings.php
+++ b/backend/database/migrations/2026_01_27_100000_add_external_registration_to_event_settings.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('event_settings', static function (Blueprint $table) {
+            $table->boolean('is_external_registration')->default(false);
+            $table->string('external_registration_url', 500)->nullable();
+            $table->string('external_registration_button_text', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('event_settings', static function (Blueprint $table) {
+            $table->dropColumn([
+                'is_external_registration',
+                'external_registration_url',
+                'external_registration_button_text',
+            ]);
+        });
+    }
+};

--- a/backend/database/migrations/2026_01_27_100001_add_external_registration_clicks_to_statistics.php
+++ b/backend/database/migrations/2026_01_27_100001_add_external_registration_clicks_to_statistics.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasColumn('event_statistics', 'external_registration_clicks')) {
+            Schema::table('event_statistics', function (Blueprint $table) {
+                $table->unsignedInteger('external_registration_clicks')->default(0);
+            });
+        }
+
+        if (!Schema::hasColumn('event_daily_statistics', 'external_registration_clicks')) {
+            Schema::table('event_daily_statistics', function (Blueprint $table) {
+                $table->unsignedInteger('external_registration_clicks')->default(0);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('event_statistics', 'external_registration_clicks')) {
+            Schema::table('event_statistics', function (Blueprint $table) {
+                $table->dropColumn('external_registration_clicks');
+            });
+        }
+
+        if (Schema::hasColumn('event_daily_statistics', 'external_registration_clicks')) {
+            Schema::table('event_daily_statistics', function (Blueprint $table) {
+                $table->dropColumn('external_registration_clicks');
+            });
+        }
+    }
+};

--- a/backend/database/migrations/2026_01_27_100002_add_external_registration_message_and_host.php
+++ b/backend/database/migrations/2026_01_27_100002_add_external_registration_message_and_host.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('event_settings', static function (Blueprint $table) {
+            $table->text('external_registration_message')->nullable();
+            $table->string('external_registration_host', 255)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('event_settings', static function (Blueprint $table) {
+            $table->dropColumn([
+                'external_registration_message',
+                'external_registration_host',
+            ]);
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -52,6 +52,7 @@ use HiEvents\Http\Actions\Events\DuplicateEventAction;
 use HiEvents\Http\Actions\Events\GetEventAction;
 use HiEvents\Http\Actions\Events\GetEventPublicAction;
 use HiEvents\Http\Actions\Events\GetEventsAction;
+use HiEvents\Http\Actions\Events\TrackExternalRegistrationClickAction;
 use HiEvents\Http\Actions\Events\GetOrganizerEventsPublicAction;
 use HiEvents\Http\Actions\Events\Images\CreateEventImageAction;
 use HiEvents\Http\Actions\Events\Images\DeleteEventImageAction;
@@ -452,6 +453,7 @@ $router->prefix('/public')->group(
     function (Router $router): void {
         // Events
         $router->get('/events/{event_id}', GetEventPublicAction::class);
+        $router->post('/events/{event_id}/external-registration-click', TrackExternalRegistrationClickAction::class);
 
         // Organizers
         $router->get('/organizers/{organizer_id}', GetPublicOrganizerAction::class);

--- a/frontend/src/api/event.client.ts
+++ b/frontend/src/api/event.client.ts
@@ -102,4 +102,9 @@ export const eventsClientPublic = {
         const response = await publicApi.get<GenericDataResponse<Event>>('events/' + eventId + (promoCode ? '?promo_code=' + promoCode : ''));
         return response.data;
     },
+
+    trackExternalRegistrationClick: async (eventId: IdParam) => {
+        const response = await publicApi.post('events/' + eventId + '/external-registration-click');
+        return response.data;
+    },
 }

--- a/frontend/src/components/common/EventCard/EventCard.module.scss
+++ b/frontend/src/components/common/EventCard/EventCard.module.scss
@@ -344,6 +344,52 @@
   font-weight: 500;
 }
 
+.externalManagementBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  background: var(--mantine-color-blue-0);
+  border: 1px solid var(--mantine-color-blue-2);
+  border-radius: var(--hi-radius-md);
+  flex-shrink: 0;
+
+  @include mixins.respond-below(lg, true) {
+    padding: 6px 12px;
+  }
+}
+
+.externalManagementText {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.externalManagementLabel {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--mantine-color-dimmed);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+
+  @include mixins.respond-below(lg, true) {
+    font-size: 9px;
+  }
+}
+
+.externalManagementHost {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--mantine-color-blue-7);
+  white-space: nowrap;
+
+  @include mixins.respond-below(lg, true) {
+    font-size: 12px;
+  }
+}
+
 .menuButton {
   flex-shrink: 0;
 

--- a/frontend/src/components/common/EventCard/index.tsx
+++ b/frontend/src/components/common/EventCard/index.tsx
@@ -165,6 +165,7 @@ export function EventCard({event}: EventCardProps) {
 
     const isEnded = event.lifecycle_status === 'ENDED';
     const isDraft = event.status === 'DRAFT';
+    const isExternalRegistration = event.settings?.is_external_registration;
 
     return (
         <>
@@ -219,6 +220,17 @@ export function EventCard({event}: EventCardProps) {
                                 )}
                             </div>
                         </div>
+
+                        {isExternalRegistration && (
+                            <div className={classes.externalManagementBadge}>
+                                <div className={classes.externalManagementText}>
+                                    <span className={classes.externalManagementLabel}>{t`Externally Managed by`}</span>
+                                    <span className={classes.externalManagementHost}>
+                                        {event.settings.external_registration_host || t`External Platform`}
+                                    </span>
+                                </div>
+                            </div>
+                        )}
 
                         <div className={classes.statsPanel}>
                             <Tooltip label={t`Attendees registered`} withArrow position="top">

--- a/frontend/src/components/common/StatBoxes/index.tsx
+++ b/frontend/src/components/common/StatBoxes/index.tsx
@@ -1,5 +1,5 @@
 import classes from "./StatBoxes.module.scss";
-import {IconCash, IconCreditCardRefund, IconEye, IconReceipt, IconShoppingCart, IconUsers} from "@tabler/icons-react";
+import {IconCash, IconCreditCardRefund, IconEye, IconExternalLink, IconReceipt, IconShoppingCart, IconUsers} from "@tabler/icons-react";
 import {Card} from "../Card";
 import {useGetEventStats} from "../../../queries/useGetEventStats.ts";
 import {useParams} from "react-router";
@@ -8,6 +8,7 @@ import {useGetEvent} from "../../../queries/useGetEvent.ts";
 import {formatCurrency} from "../../../utilites/currency.ts";
 import {formatNumber} from "../../../utilites/helpers.ts";
 import {ReactNode} from "react";
+import {useGetEventSettings} from "../../../queries/useGetEventSettings.ts";
 
 interface StatBoxProps {
     number: string | number;
@@ -38,6 +39,7 @@ export const StatBoxes = () => {
     const eventQuery = useGetEvent(eventId);
     const event = eventQuery?.data;
     const {data: eventStats} = eventStatsQuery;
+    const {data: eventSettings} = useGetEventSettings(eventId);
 
     const data = [
         {
@@ -77,6 +79,15 @@ export const StatBoxes = () => {
             backgroundColor: '#E67D49'
         }
     ];
+
+    if (eventSettings?.is_external_registration) {
+        data.push({
+            number: formatNumber(eventStats?.total_external_registration_clicks as number),
+            description: t`Redirections`,
+            icon: <IconExternalLink size={18}/>,
+            backgroundColor: '#F59E0B'
+        });
+    }
 
     return (
         <div className={classes.statistics}>

--- a/frontend/src/components/layouts/AppLayout/Sidebar/index.tsx
+++ b/frontend/src/components/layouts/AppLayout/Sidebar/index.tsx
@@ -27,16 +27,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
     const renderLinks = () => {
         return navItems.map((item) => {
 
+            if (item.showWhen && !item.showWhen()) {
+                return null;
+            }
+
             if (!item.link && item.link !== "" && item.onClick === undefined) {
                 return (
                     <div className={classes.sectionHeading} key={item.label}>
                         {item.label}
                     </div>
                 );
-            }
-
-            if (item.showWhen && !item.showWhen()) {
-                return null;
             }
 
             if (item.loading) {

--- a/frontend/src/components/layouts/Event/index.tsx
+++ b/frontend/src/components/layouts/Event/index.tsx
@@ -100,22 +100,69 @@ const EventLayout = () => {
         {label: t`Setup & Design`},
         {link: 'settings', label: t`Event Settings`, icon: IconSettings},
         {link: 'homepage-designer', label: t`Homepage Designer`, icon: IconPaint},
-        {link: 'ticket-designer', label: t`Ticket Designer`, icon: IconTicket},
-        {link: 'questions', label: t`Registration Questions`, icon: IconUserQuestion},
+        {
+            link: 'ticket-designer',
+            label: t`Ticket Designer`,
+            icon: IconTicket,
+            showWhen: () => !eventSettings?.is_external_registration
+        },
+        {
+            link: 'questions',
+            label: t`Registration Questions`,
+            icon: IconUserQuestion,
+            showWhen: () => !eventSettings?.is_external_registration
+        },
 
         // 3. Ticketing & Sales
         {label: t`Ticketing & Sales`},
-        {link: 'products', label: t`Tickets & Products`, icon: IconTicket},
-        {link: 'orders', label: t`Orders`, icon: IconReceipt, badge: eventStats?.total_orders},
-        {link: 'promo-codes', label: t`Promo Codes`, icon: IconDiscount2},
-        {link: 'affiliates', label: t`Affiliates`, icon: IconTrendingUp},
+        {
+            link: 'products',
+            label: t`Tickets & Products`,
+            icon: IconTicket
+        },
+        {
+            link: 'orders',
+            label: t`Orders`,
+            icon: IconReceipt,
+            badge: eventStats?.total_orders,
+            showWhen: () => !eventSettings?.is_external_registration
+        },
+        {
+            link: 'promo-codes',
+            label: t`Promo Codes`,
+            icon: IconDiscount2,
+            showWhen: () => !eventSettings?.is_external_registration
+        },
+        {
+            link: 'affiliates',
+            label: t`Affiliates`,
+            icon: IconTrendingUp,
+            showWhen: () => !eventSettings?.is_external_registration
+        },
 
         // 4. GUESTS
         {label: t`Guest Management`},
-        {link: 'attendees', label: t`Attendees`, icon: IconUsers, badge: eventStats?.total_attendees_registered},
-        {link: 'check-in', label: t`Check-In Lists`, icon: IconQrcode},
-        {link: 'messages', label: t`Messages`, icon: IconSend},
-        {link: 'capacity-assignments', label: t`Capacity Management`, icon: IconUsersGroup},
+        {
+            link: 'attendees',
+            label: t`Attendees`,
+            icon: IconUsers,
+            badge: eventStats?.total_attendees_registered
+        },
+        {
+            link: 'check-in',
+            label: t`Check-In Lists`,
+            icon: IconQrcode
+        },
+        {
+            link: 'messages',
+            label: t`Messages`,
+            icon: IconSend
+        },
+        {
+            link: 'capacity-assignments',
+            label: t`Capacity Management`,
+            icon: IconUsersGroup
+        },
 
         // 5. INTEGRATIONS
         {label: t`Integrations`},

--- a/frontend/src/components/layouts/EventHomepage/EventHomepage.module.scss
+++ b/frontend/src/components/layouts/EventHomepage/EventHomepage.module.scss
@@ -1336,3 +1336,68 @@ $transition-slow: 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     height: 0.9rem;
   }
 }
+
+// External registration styles
+.externalRegistrationCard {
+  background: var(--card-background);
+  border-radius: $radius-lg;
+  padding: 32px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+
+  @include mixins.respond-below(sm) {
+    padding: 24px;
+  }
+}
+
+.externalRegistrationHost {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin: 0;
+  line-height: 1.5;
+
+  strong {
+    color: var(--primary-text-color);
+    font-weight: 600;
+  }
+}
+
+.externalRegistrationMessage {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.externalRegistrationButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--primary-color);
+  color: var(--accent-contrast);
+  font-family: $font-display;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 14px 28px;
+  border-radius: 50px;
+  text-decoration: none;
+  transition: all $transition-fast;
+  box-shadow: 0 2px 12px var(--accent-soft);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 20px var(--accent-soft);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  @include mixins.respond-below(sm) {
+    padding: 12px 24px;
+    font-size: 0.9375rem;
+  }
+}

--- a/frontend/src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+++ b/frontend/src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
@@ -1,0 +1,149 @@
+import {t} from "@lingui/macro";
+import {Button, Switch, TextInput, Textarea} from "@mantine/core";
+import {useForm} from "@mantine/form";
+import {useParams} from "react-router";
+import {useEffect} from "react";
+import {EventSettings} from "../../../../../../types.ts";
+import {Card} from "../../../../../common/Card";
+import {showSuccess} from "../../../../../../utilites/notifications.tsx";
+import {useFormErrorResponseHandler} from "../../../../../../hooks/useFormErrorResponseHandler.tsx";
+import {useUpdateEventSettings} from "../../../../../../mutations/useUpdateEventSettings.ts";
+import {useGetEventSettings} from "../../../../../../queries/useGetEventSettings.ts";
+import {HeadingWithDescription} from "../../../../../common/Card/CardHeading";
+import {IconExternalLink, IconUser} from "@tabler/icons-react";
+
+export const RegistrationSettings = () => {
+    const {eventId} = useParams();
+    const eventSettingsQuery = useGetEventSettings(eventId);
+    const updateMutation = useUpdateEventSettings();
+    const form = useForm({
+        initialValues: {
+            is_external_registration: false,
+            external_registration_url: '',
+            external_registration_button_text: '',
+            external_registration_message: '',
+            external_registration_host: '',
+        },
+        validate: {
+            external_registration_url: (value, values) => {
+                if (values.is_external_registration && !value) {
+                    return t`External registration URL is required`;
+                }
+                if (value && !value.match(/^https?:\/\/.+/)) {
+                    return t`Please enter a valid URL`;
+                }
+            },
+            external_registration_button_text: (value, values) => {
+                if (values.is_external_registration && !value) {
+                    return t`Button text is required`;
+                }
+            },
+        },
+    });
+    const formErrorHandle = useFormErrorResponseHandler();
+
+    useEffect(() => {
+        if (eventSettingsQuery?.isFetched && eventSettingsQuery?.data) {
+            form.setValues({
+                is_external_registration: eventSettingsQuery.data.is_external_registration ?? false,
+                external_registration_url: eventSettingsQuery.data.external_registration_url ?? '',
+                external_registration_button_text: eventSettingsQuery.data.external_registration_button_text ?? '',
+                external_registration_message: eventSettingsQuery.data.external_registration_message ?? '',
+                external_registration_host: eventSettingsQuery.data.external_registration_host ?? '',
+            });
+        }
+    }, [eventSettingsQuery.isFetched]);
+
+    const handleSubmit = (values: Partial<EventSettings>) => {
+        updateMutation.mutate({
+            eventSettings: values,
+            eventId: eventId,
+        }, {
+            onSuccess: () => {
+                showSuccess(t`Registration settings updated successfully`);
+            },
+            onError: (error) => {
+                formErrorHandle(form, error);
+            }
+        });
+    }
+
+    return (
+        <Card>
+            <HeadingWithDescription
+                heading={t`Registration Settings`}
+                description={t`Configure how attendees register for your event`}
+            />
+            <form onSubmit={form.onSubmit(handleSubmit as any)}>
+                <fieldset disabled={eventSettingsQuery.isLoading || updateMutation.isPending}>
+                    <Switch
+                        {...form.getInputProps('is_external_registration', {type: 'checkbox'})}
+                        label={t`Use external registration`}
+                        description={t`Enable this if you're using an external platform like Luma, Eventbrite, or your own registration system`}
+                        mb="md"
+                    />
+
+                    {form.values.is_external_registration && (
+                        <>
+                            <TextInput
+                                {...form.getInputProps('external_registration_host')}
+                                label={t`Event Host / Organizer`}
+                                placeholder={t`Luma`}
+                                description={t`The name of the external platform or organizer hosting the registration`}
+                                leftSection={<IconUser size={18}/>}
+                                maxLength={255}
+                                mb="md"
+                            />
+
+                            <TextInput
+                                {...form.getInputProps('external_registration_url')}
+                                label={t`External Registration URL`}
+                                placeholder="https://lu.ma/your-event"
+                                description={t`The URL where attendees will be redirected to register`}
+                                required
+                                leftSection={<IconExternalLink size={18}/>}
+                                mb="md"
+                            />
+
+                            <TextInput
+                                {...form.getInputProps('external_registration_button_text')}
+                                label={t`Button Text`}
+                                placeholder={t`Register on Luma`}
+                                description={t`The text shown on the registration button`}
+                                required
+                                maxLength={100}
+                                mb="md"
+                            />
+
+                            <Textarea
+                                {...form.getInputProps('external_registration_message')}
+                                label={t`Registration Message`}
+                                placeholder={t`This event uses external registration.`}
+                                description={t`The message shown on the event page explaining external registration`}
+                                maxLength={500}
+                                rows={3}
+                                mb="md"
+                            />
+
+                            <div style={{
+                                background: 'var(--mantine-color-yellow-0)',
+                                border: '1px solid var(--mantine-color-yellow-3)',
+                                borderRadius: '8px',
+                                padding: '12px 16px',
+                                marginBottom: '16px',
+                            }}>
+                                <p style={{margin: 0, fontSize: '0.875rem', color: 'var(--mantine-color-yellow-9)'}}>
+                                    <strong>{t`Note:`}</strong> {t`When external registration is enabled, the ticket selection and checkout will be hidden. Attendees will be redirected to your external registration URL.`}
+                                </p>
+                            </div>
+                        </>
+                    )}
+
+                    <Button loading={updateMutation.isPending} type={'submit'}>
+                        {t`Save Changes`}
+                    </Button>
+                </fieldset>
+            </form>
+        </Card>
+    );
+}

--- a/frontend/src/components/routes/event/Settings/index.tsx
+++ b/frontend/src/components/routes/event/Settings/index.tsx
@@ -7,6 +7,7 @@ import {PageTitle} from "../../../common/PageTitle";
 import {t} from "@lingui/macro";
 import {SeoSettings} from "./Sections/SeoSettings";
 import {MiscSettings} from "./Sections/MiscSettings";
+import {RegistrationSettings} from "./Sections/RegistrationSettings";
 import {Box, Group, NavLink as MantineNavLink, Stack} from "@mantine/core";
 import {
     IconAdjustments,
@@ -17,6 +18,7 @@ import {
     IconHome,
     IconMapPin,
     IconPercentage,
+    IconTicket,
 } from "@tabler/icons-react";
 import {useMediaQuery} from "@mantine/hooks";
 import {useMemo, useState} from "react";
@@ -24,10 +26,15 @@ import {Card} from "../../../common/Card";
 import {PaymentAndInvoicingSettings} from "./Sections/PaymentSettings";
 import {PlatformFeesSettings} from "./Sections/PlatformFeesSettings";
 import {useGetAccount} from "../../../../queries/useGetAccount.ts";
+import {useParams} from "react-router";
+import {useGetEventSettings} from "../../../../queries/useGetEventSettings.ts";
 
 export const Settings = () => {
+    const {eventId} = useParams();
     const {data: account} = useGetAccount();
+    const {data: eventSettings} = useGetEventSettings(eventId);
     const isSaasMode = account?.is_saas_mode_enabled;
+    const isExternalRegistration = eventSettings?.is_external_registration;
 
     const SECTIONS = useMemo(() => {
         const baseSections = [
@@ -42,6 +49,12 @@ export const Settings = () => {
                 label: t`Location`,
                 icon: IconMapPin,
                 component: LocationSettings
+            },
+            {
+                id: 'registration-settings',
+                label: t`Registration`,
+                icon: IconTicket,
+                component: RegistrationSettings
             },
             {
                 id: 'homepage-settings',
@@ -84,8 +97,15 @@ export const Settings = () => {
             });
         }
 
+        // Hide certain sections when external registration is enabled
+        if (isExternalRegistration) {
+            return baseSections.filter(section =>
+                !['homepage-settings', 'seo-settings', 'email-settings', 'misc-settings', 'payment-settings', 'platform-fees'].includes(section.id)
+            );
+        }
+
         return baseSections;
-    }, [isSaasMode]);
+    }, [isSaasMode, isExternalRegistration]);
 
     const isLargeScreen = useMediaQuery('(min-width: 1200px)', true);
     const [activeSection, setActiveSection] = useState('event-details');

--- a/frontend/src/locales.ts
+++ b/frontend/src/locales.ts
@@ -60,10 +60,6 @@ export const getLocaleName = (locale: SupportedLocales) => {
 }
 
 export const getClientLocale = () => {
-    // TEMPORARY: Force English locale - REVERT THIS LATER
-    return "en";
-
-    /* Original implementation - uncomment to restore language detection
     if (typeof window !== "undefined") {
         const storedLocale = document
             .cookie
@@ -79,7 +75,6 @@ export const getClientLocale = () => {
     }
 
     return "en";
-    */
 };
 
 export async function dynamicActivateLocale(locale: string) {

--- a/frontend/src/locales.ts
+++ b/frontend/src/locales.ts
@@ -60,6 +60,10 @@ export const getLocaleName = (locale: SupportedLocales) => {
 }
 
 export const getClientLocale = () => {
+    // TEMPORARY: Force English locale - REVERT THIS LATER
+    return "en";
+
+    /* Original implementation - uncomment to restore language detection
     if (typeof window !== "undefined") {
         const storedLocale = document
             .cookie
@@ -75,6 +79,7 @@ export const getClientLocale = () => {
     }
 
     return "en";
+    */
 };
 
 export async function dynamicActivateLocale(locale: string) {

--- a/frontend/src/locales/de.po
+++ b/frontend/src/locales/de.po
@@ -9606,3 +9606,97 @@ msgstr "Postleitzahl"
 #: src/components/routes/product-widget/CollectInformation/index.tsx:523
 msgid "ZIP or Postal Code"
 msgstr "Postleitzahl"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Registration Settings"
+msgstr "Registrierungseinstellungen"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Configure how attendees register for your event"
+msgstr "Konfigurieren Sie, wie sich Teilnehmer für Ihre Veranstaltung registrieren"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Use external registration"
+msgstr "Externe Registrierung verwenden"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Enable this if you're using an external platform like Luma, Eventbrite, or your own registration system"
+msgstr "Aktivieren Sie dies, wenn Sie eine externe Plattform wie Luma, Eventbrite oder Ihr eigenes Registrierungssystem verwenden"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "External Registration URL"
+msgstr "Externe Registrierungs-URL"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "The URL where attendees will be redirected to register"
+msgstr "Die URL, zu der Teilnehmer zur Registrierung weitergeleitet werden"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Button Text"
+msgstr "Schaltflächentext"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "The text shown on the registration button"
+msgstr "Der auf der Registrierungsschaltfläche angezeigte Text"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Register on Luma"
+msgstr "Auf Luma registrieren"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Note:"
+msgstr "Hinweis:"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "When external registration is enabled, the ticket selection and checkout will be hidden. Attendees will be redirected to your external registration URL."
+msgstr "Wenn die externe Registrierung aktiviert ist, werden die Ticketauswahl und der Checkout ausgeblendet. Teilnehmer werden zu Ihrer externen Registrierungs-URL weitergeleitet."
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Save Changes"
+msgstr "Änderungen speichern"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Registration settings updated successfully"
+msgstr "Registrierungseinstellungen erfolgreich aktualisiert"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "External registration URL is required"
+msgstr "Externe Registrierungs-URL ist erforderlich"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Please enter a valid URL"
+msgstr "Bitte geben Sie eine gültige URL ein"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Button text is required"
+msgstr "Schaltflächentext ist erforderlich"
+
+#: src/components/layouts/EventHomepage/index.tsx
+msgid "Register Externally"
+msgstr "Extern registrieren"
+
+#: src/components/layouts/EventHomepage/index.tsx
+msgid "Registration"
+msgstr "Registrierung"
+
+#: src/components/layouts/EventHomepage/index.tsx
+msgid "This event uses external registration."
+msgstr "Diese Veranstaltung verwendet externe Registrierung."
+
+msgid "Event Host / Organizer"
+msgstr "Veranstalter"
+
+msgid "Registration Message"
+msgstr "Registrierungsnachricht"
+
+msgid "The name of the external platform or organizer hosting the registration"
+msgstr "Der Name der externen Plattform oder des Veranstalters, der die Registrierung hostet"
+
+msgid "The message shown on the event page explaining external registration"
+msgstr "Die Nachricht, die auf der Veranstaltungsseite angezeigt wird, um die externe Registrierung zu erklären"
+
+msgid "Hosted by:"
+msgstr "Veranstaltet von:"
+
+msgid "Luma"
+msgstr "Luma"

--- a/frontend/src/locales/de.po
+++ b/frontend/src/locales/de.po
@@ -9671,6 +9671,10 @@ msgstr "Bitte geben Sie eine gültige URL ein"
 msgid "Button text is required"
 msgstr "Schaltflächentext ist erforderlich"
 
+#: src/components/common/StatBoxes/index.tsx
+msgid "External Registration Clicks"
+msgstr "Externe Registrierungs-Klicks"
+
 #: src/components/layouts/EventHomepage/index.tsx
 msgid "Register Externally"
 msgstr "Extern registrieren"

--- a/frontend/src/locales/es.po
+++ b/frontend/src/locales/es.po
@@ -9671,6 +9671,10 @@ msgstr "Por favor, ingrese una URL válida"
 msgid "Button text is required"
 msgstr "Se requiere texto del botón"
 
+#: src/components/common/StatBoxes/index.tsx
+msgid "External Registration Clicks"
+msgstr "Clics de registro externo"
+
 #: src/components/layouts/EventHomepage/index.tsx
 msgid "Register Externally"
 msgstr "Registrarse externamente"

--- a/frontend/src/locales/es.po
+++ b/frontend/src/locales/es.po
@@ -9606,3 +9606,97 @@ msgstr "CP o Código Postal"
 #: src/components/routes/product-widget/CollectInformation/index.tsx:523
 msgid "ZIP or Postal Code"
 msgstr "Código postal"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Registration Settings"
+msgstr "Configuración de registro"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Configure how attendees register for your event"
+msgstr "Configure cómo los asistentes se registran para su evento"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Use external registration"
+msgstr "Usar registro externo"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Enable this if you're using an external platform like Luma, Eventbrite, or your own registration system"
+msgstr "Habilite esto si está usando una plataforma externa como Luma, Eventbrite o su propio sistema de registro"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "External Registration URL"
+msgstr "URL de registro externo"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "The URL where attendees will be redirected to register"
+msgstr "La URL a la que se redirigirá a los asistentes para registrarse"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Button Text"
+msgstr "Texto del botón"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "The text shown on the registration button"
+msgstr "El texto que se muestra en el botón de registro"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Register on Luma"
+msgstr "Registrarse en Luma"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Note:"
+msgstr "Nota:"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "When external registration is enabled, the ticket selection and checkout will be hidden. Attendees will be redirected to your external registration URL."
+msgstr "Cuando el registro externo está habilitado, la selección de entradas y el proceso de pago se ocultarán. Los asistentes serán redirigidos a su URL de registro externo."
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Save Changes"
+msgstr "Guardar cambios"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Registration settings updated successfully"
+msgstr "Configuración de registro actualizada correctamente"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "External registration URL is required"
+msgstr "Se requiere URL de registro externo"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Please enter a valid URL"
+msgstr "Por favor, ingrese una URL válida"
+
+#: src/components/routes/event/Settings/Sections/RegistrationSettings/index.tsx
+msgid "Button text is required"
+msgstr "Se requiere texto del botón"
+
+#: src/components/layouts/EventHomepage/index.tsx
+msgid "Register Externally"
+msgstr "Registrarse externamente"
+
+#: src/components/layouts/EventHomepage/index.tsx
+msgid "Registration"
+msgstr "Registro"
+
+#: src/components/layouts/EventHomepage/index.tsx
+msgid "This event uses external registration."
+msgstr "Este evento utiliza registro externo."
+
+msgid "Event Host / Organizer"
+msgstr "Organizador del evento"
+
+msgid "Registration Message"
+msgstr "Mensaje de registro"
+
+msgid "The name of the external platform or organizer hosting the registration"
+msgstr "El nombre de la plataforma externa o el organizador que aloja el registro"
+
+msgid "The message shown on the event page explaining external registration"
+msgstr "El mensaje que se muestra en la página del evento explicando el registro externo"
+
+msgid "Hosted by:"
+msgstr "Organizado por:"
+
+msgid "Luma"
+msgstr "Luma"

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -9620,6 +9620,63 @@ msgstr "Le nom de la plateforme externe ou de l'organisateur hébergeant l'inscr
 msgid "The message shown on the event page explaining external registration"
 msgstr "Le message affiché sur la page de l'événement expliquant l'inscription externe"
 
+msgid "Registration Settings"
+msgstr "Paramètres d'inscription"
+
+msgid "Configure how attendees register for your event"
+msgstr "Configurez comment les participants s'inscrivent à votre événement"
+
+msgid "Use external registration"
+msgstr "Utiliser l'inscription externe"
+
+msgid "Enable this if you're using an external platform like Luma, Eventbrite, or your own registration system"
+msgstr "Activez ceci si vous utilisez une plateforme externe comme Luma, Eventbrite ou votre propre système d'inscription"
+
+msgid "External Registration URL"
+msgstr "URL d'inscription externe"
+
+msgid "The URL where attendees will be redirected to register"
+msgstr "L'URL vers laquelle les participants seront redirigés pour s'inscrire"
+
+msgid "Button Text"
+msgstr "Texte du bouton"
+
+msgid "Register on Luma"
+msgstr "S'inscrire sur Luma"
+
+msgid "The text shown on the registration button"
+msgstr "Le texte affiché sur le bouton d'inscription"
+
+msgid "This event uses external registration."
+msgstr "Cet événement utilise l'inscription externe."
+
+msgid "Note:"
+msgstr "Remarque :"
+
+msgid "When external registration is enabled, the ticket selection and checkout will be hidden. Attendees will be redirected to your external registration URL."
+msgstr "Lorsque l'inscription externe est activée, la sélection de billets et le paiement seront masqués. Les participants seront redirigés vers votre URL d'inscription externe."
+
+msgid "Save Changes"
+msgstr "Enregistrer les modifications"
+
+msgid "Registration settings updated successfully"
+msgstr "Paramètres d'inscription mis à jour avec succès"
+
+msgid "External registration URL is required"
+msgstr "L'URL d'inscription externe est requise"
+
+msgid "Please enter a valid URL"
+msgstr "Veuillez entrer une URL valide"
+
+msgid "Button text is required"
+msgstr "Le texte du bouton est requis"
+
+msgid "Register Externally"
+msgstr "S'inscrire en externe"
+
+msgid "External Registration Clicks"
+msgstr "Clics d'inscription externe"
+
 msgid "Hosted by:"
 msgstr "Organisé par :"
 

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -9607,3 +9607,21 @@ msgstr "Code Postal"
 #: src/components/routes/product-widget/CollectInformation/index.tsx:523
 msgid "ZIP or Postal Code"
 msgstr "Code postal"
+
+msgid "Event Host / Organizer"
+msgstr "Organisateur de l'événement"
+
+msgid "Registration Message"
+msgstr "Message d'inscription"
+
+msgid "The name of the external platform or organizer hosting the registration"
+msgstr "Le nom de la plateforme externe ou de l'organisateur hébergeant l'inscription"
+
+msgid "The message shown on the event page explaining external registration"
+msgstr "Le message affiché sur la page de l'événement expliquant l'inscription externe"
+
+msgid "Hosted by:"
+msgstr "Organisé par :"
+
+msgid "Luma"
+msgstr "Luma"

--- a/frontend/src/locales/it.po
+++ b/frontend/src/locales/it.po
@@ -9608,3 +9608,57 @@ msgstr "CAP o Codice Postale"
 #: src/components/routes/product-widget/CollectInformation/index.tsx:523
 msgid "ZIP or Postal Code"
 msgstr "CAP o Codice Postale"
+
+msgid "Registration Settings"
+msgstr "Impostazioni di registrazione"
+
+msgid "Configure how attendees register for your event"
+msgstr "Configura come i partecipanti si registrano al tuo evento"
+
+msgid "Use external registration"
+msgstr "Usa registrazione esterna"
+
+msgid "Enable this if you're using an external platform like Luma, Eventbrite, or your own registration system"
+msgstr "Abilita questo se stai usando una piattaforma esterna come Luma, Eventbrite o il tuo sistema di registrazione"
+
+msgid "External Registration URL"
+msgstr "URL di registrazione esterna"
+
+msgid "The URL where attendees will be redirected to register"
+msgstr "L'URL a cui i partecipanti verranno reindirizzati per registrarsi"
+
+msgid "Register on Luma"
+msgstr "Registrati su Luma"
+
+msgid "Registration settings updated successfully"
+msgstr "Impostazioni di registrazione aggiornate con successo"
+
+msgid "External registration URL is required"
+msgstr "L'URL di registrazione esterna è obbligatorio"
+
+msgid "Button text is required"
+msgstr "Il testo del pulsante è obbligatorio"
+
+msgid "Register Externally"
+msgstr "Registrati esternamente"
+
+msgid "This event uses external registration."
+msgstr "Questo evento utilizza la registrazione esterna."
+
+msgid "Event Host / Organizer"
+msgstr "Organizzatore dell'evento"
+
+msgid "Registration Message"
+msgstr "Messaggio di registrazione"
+
+msgid "The name of the external platform or organizer hosting the registration"
+msgstr "Il nome della piattaforma esterna o dell'organizzatore che ospita la registrazione"
+
+msgid "The message shown on the event page explaining external registration"
+msgstr "Il messaggio mostrato sulla pagina dell'evento che spiega la registrazione esterna"
+
+msgid "Hosted by:"
+msgstr "Organizzato da:"
+
+msgid "Luma"
+msgstr "Luma"

--- a/frontend/src/locales/it.po
+++ b/frontend/src/locales/it.po
@@ -9630,6 +9630,9 @@ msgstr "L'URL a cui i partecipanti verranno reindirizzati per registrarsi"
 msgid "Register on Luma"
 msgstr "Registrati su Luma"
 
+msgid "The text shown on the registration button"
+msgstr "Il testo mostrato sul pulsante di registrazione"
+
 msgid "Registration settings updated successfully"
 msgstr "Impostazioni di registrazione aggiornate con successo"
 
@@ -9656,6 +9659,15 @@ msgstr "Il nome della piattaforma esterna o dell'organizzatore che ospita la reg
 
 msgid "The message shown on the event page explaining external registration"
 msgstr "Il messaggio mostrato sulla pagina dell'evento che spiega la registrazione esterna"
+
+msgid "Note:"
+msgstr "Nota:"
+
+msgid "When external registration is enabled, the ticket selection and checkout will be hidden. Attendees will be redirected to your external registration URL."
+msgstr "Quando la registrazione esterna è abilitata, la selezione dei biglietti e il checkout saranno nascosti. I partecipanti verranno reindirizzati al tuo URL di registrazione esterno."
+
+msgid "External Registration Clicks"
+msgstr "Clic di registrazione esterna"
 
 msgid "Hosted by:"
 msgstr "Organizzato da:"

--- a/frontend/src/locales/nl.po
+++ b/frontend/src/locales/nl.po
@@ -9607,3 +9607,21 @@ msgstr "Postcode"
 #: src/components/routes/product-widget/CollectInformation/index.tsx:523
 msgid "ZIP or Postal Code"
 msgstr "Postcode"
+
+msgid "Event Host / Organizer"
+msgstr "Evenementorganisator"
+
+msgid "Registration Message"
+msgstr "Registratiebericht"
+
+msgid "The name of the external platform or organizer hosting the registration"
+msgstr "De naam van het externe platform of de organisator die de registratie host"
+
+msgid "The message shown on the event page explaining external registration"
+msgstr "Het bericht dat op de evenementpagina wordt weergegeven ter uitleg van externe registratie"
+
+msgid "Hosted by:"
+msgstr "Georganiseerd door:"
+
+msgid "Luma"
+msgstr "Luma"

--- a/frontend/src/locales/nl.po
+++ b/frontend/src/locales/nl.po
@@ -9620,6 +9620,63 @@ msgstr "De naam van het externe platform of de organisator die de registratie ho
 msgid "The message shown on the event page explaining external registration"
 msgstr "Het bericht dat op de evenementpagina wordt weergegeven ter uitleg van externe registratie"
 
+msgid "Registration Settings"
+msgstr "Registratie-instellingen"
+
+msgid "Configure how attendees register for your event"
+msgstr "Configureer hoe deelnemers zich registreren voor uw evenement"
+
+msgid "Use external registration"
+msgstr "Externe registratie gebruiken"
+
+msgid "Enable this if you're using an external platform like Luma, Eventbrite, or your own registration system"
+msgstr "Schakel dit in als u een extern platform zoals Luma, Eventbrite of uw eigen registratiesysteem gebruikt"
+
+msgid "External Registration URL"
+msgstr "Externe registratie-URL"
+
+msgid "The URL where attendees will be redirected to register"
+msgstr "De URL waarnaar deelnemers worden doorverwezen om te registreren"
+
+msgid "Button Text"
+msgstr "Knoptekst"
+
+msgid "Register on Luma"
+msgstr "Registreren op Luma"
+
+msgid "The text shown on the registration button"
+msgstr "De tekst die op de registratieknop wordt weergegeven"
+
+msgid "This event uses external registration."
+msgstr "Dit evenement maakt gebruik van externe registratie."
+
+msgid "Note:"
+msgstr "Opmerking:"
+
+msgid "When external registration is enabled, the ticket selection and checkout will be hidden. Attendees will be redirected to your external registration URL."
+msgstr "Wanneer externe registratie is ingeschakeld, worden de ticketselectie en checkout verborgen. Deelnemers worden doorverwezen naar uw externe registratie-URL."
+
+msgid "Save Changes"
+msgstr "Wijzigingen opslaan"
+
+msgid "Registration settings updated successfully"
+msgstr "Registratie-instellingen succesvol bijgewerkt"
+
+msgid "External registration URL is required"
+msgstr "Externe registratie-URL is vereist"
+
+msgid "Please enter a valid URL"
+msgstr "Voer een geldige URL in"
+
+msgid "Button text is required"
+msgstr "Knoptekst is vereist"
+
+msgid "Register Externally"
+msgstr "Extern registreren"
+
+msgid "External Registration Clicks"
+msgstr "Externe registratiekliks"
+
 msgid "Hosted by:"
 msgstr "Georganiseerd door:"
 

--- a/frontend/src/locales/pl.po
+++ b/frontend/src/locales/pl.po
@@ -9633,6 +9633,63 @@ msgstr "Nazwa zewnętrznej platformy lub organizatora hostującego rejestrację"
 msgid "The message shown on the event page explaining external registration"
 msgstr "Komunikat wyświetlany na stronie wydarzenia wyjaśniający rejestrację zewnętrzną"
 
+msgid "Registration Settings"
+msgstr "Ustawienia rejestracji"
+
+msgid "Configure how attendees register for your event"
+msgstr "Skonfiguruj sposób rejestracji uczestników na Twoje wydarzenie"
+
+msgid "Use external registration"
+msgstr "Użyj rejestracji zewnętrznej"
+
+msgid "Enable this if you're using an external platform like Luma, Eventbrite, or your own registration system"
+msgstr "Włącz to, jeśli używasz zewnętrznej platformy, takiej jak Luma, Eventbrite lub własnego systemu rejestracji"
+
+msgid "External Registration URL"
+msgstr "URL rejestracji zewnętrznej"
+
+msgid "The URL where attendees will be redirected to register"
+msgstr "Adres URL, do którego uczestnicy zostaną przekierowani w celu rejestracji"
+
+msgid "Button Text"
+msgstr "Tekst przycisku"
+
+msgid "Register on Luma"
+msgstr "Zarejestruj się na Luma"
+
+msgid "The text shown on the registration button"
+msgstr "Tekst wyświetlany na przycisku rejestracji"
+
+msgid "This event uses external registration."
+msgstr "To wydarzenie korzysta z rejestracji zewnętrznej."
+
+msgid "Note:"
+msgstr "Uwaga:"
+
+msgid "When external registration is enabled, the ticket selection and checkout will be hidden. Attendees will be redirected to your external registration URL."
+msgstr "Gdy rejestracja zewnętrzna jest włączona, wybór biletów i kasa będą ukryte. Uczestnicy zostaną przekierowani do Twojego adresu URL rejestracji zewnętrznej."
+
+msgid "Save Changes"
+msgstr "Zapisz zmiany"
+
+msgid "Registration settings updated successfully"
+msgstr "Ustawienia rejestracji zaktualizowane pomyślnie"
+
+msgid "External registration URL is required"
+msgstr "URL rejestracji zewnętrznej jest wymagany"
+
+msgid "Please enter a valid URL"
+msgstr "Proszę wprowadzić prawidłowy adres URL"
+
+msgid "Button text is required"
+msgstr "Tekst przycisku jest wymagany"
+
+msgid "Register Externally"
+msgstr "Zarejestruj się zewnętrznie"
+
+msgid "External Registration Clicks"
+msgstr "Kliknięcia rejestracji zewnętrznej"
+
 msgid "Hosted by:"
 msgstr "Organizowane przez:"
 

--- a/frontend/src/locales/pl.po
+++ b/frontend/src/locales/pl.po
@@ -9620,3 +9620,21 @@ msgstr "Kod pocztowy"
 # Minimal Polish translations (add more via `lingui extract`/`lingui compile`)
 #~ msgid "Welcome"
 #~ msgstr "Witamy"
+
+msgid "Event Host / Organizer"
+msgstr "Organizator wydarzenia"
+
+msgid "Registration Message"
+msgstr "Komunikat rejestracyjny"
+
+msgid "The name of the external platform or organizer hosting the registration"
+msgstr "Nazwa zewnętrznej platformy lub organizatora hostującego rejestrację"
+
+msgid "The message shown on the event page explaining external registration"
+msgstr "Komunikat wyświetlany na stronie wydarzenia wyjaśniający rejestrację zewnętrzną"
+
+msgid "Hosted by:"
+msgstr "Organizowane przez:"
+
+msgid "Luma"
+msgstr "Luma"

--- a/frontend/src/locales/pt-br.po
+++ b/frontend/src/locales/pt-br.po
@@ -9606,3 +9606,21 @@ msgstr "CEP ou código postal"
 #: src/components/routes/product-widget/CollectInformation/index.tsx:523
 msgid "ZIP or Postal Code"
 msgstr "CEP ou Código Postal"
+
+msgid "Event Host / Organizer"
+msgstr "Organizador do evento"
+
+msgid "Registration Message"
+msgstr "Mensagem de registro"
+
+msgid "The name of the external platform or organizer hosting the registration"
+msgstr "O nome da plataforma externa ou organizador que hospeda o registro"
+
+msgid "The message shown on the event page explaining external registration"
+msgstr "A mensagem mostrada na página do evento explicando o registro externo"
+
+msgid "Hosted by:"
+msgstr "Organizado por:"
+
+msgid "Luma"
+msgstr "Luma"

--- a/frontend/src/locales/pt-br.po
+++ b/frontend/src/locales/pt-br.po
@@ -9619,6 +9619,63 @@ msgstr "O nome da plataforma externa ou organizador que hospeda o registro"
 msgid "The message shown on the event page explaining external registration"
 msgstr "A mensagem mostrada na página do evento explicando o registro externo"
 
+msgid "Registration Settings"
+msgstr "Configurações de registro"
+
+msgid "Configure how attendees register for your event"
+msgstr "Configure como os participantes se registram no seu evento"
+
+msgid "Use external registration"
+msgstr "Usar registro externo"
+
+msgid "Enable this if you're using an external platform like Luma, Eventbrite, or your own registration system"
+msgstr "Ative isso se estiver usando uma plataforma externa como Luma, Eventbrite ou seu próprio sistema de registro"
+
+msgid "External Registration URL"
+msgstr "URL de registro externo"
+
+msgid "The URL where attendees will be redirected to register"
+msgstr "O URL para onde os participantes serão redirecionados para se registrar"
+
+msgid "Button Text"
+msgstr "Texto do botão"
+
+msgid "Register on Luma"
+msgstr "Registrar no Luma"
+
+msgid "The text shown on the registration button"
+msgstr "O texto mostrado no botão de registro"
+
+msgid "This event uses external registration."
+msgstr "Este evento usa registro externo."
+
+msgid "Note:"
+msgstr "Observação:"
+
+msgid "When external registration is enabled, the ticket selection and checkout will be hidden. Attendees will be redirected to your external registration URL."
+msgstr "Quando o registro externo está ativado, a seleção de ingressos e o checkout serão ocultos. Os participantes serão redirecionados para o seu URL de registro externo."
+
+msgid "Save Changes"
+msgstr "Salvar alterações"
+
+msgid "Registration settings updated successfully"
+msgstr "Configurações de registro atualizadas com sucesso"
+
+msgid "External registration URL is required"
+msgstr "URL de registro externo é obrigatório"
+
+msgid "Please enter a valid URL"
+msgstr "Por favor, insira um URL válido"
+
+msgid "Button text is required"
+msgstr "O texto do botão é obrigatório"
+
+msgid "Register Externally"
+msgstr "Registrar externamente"
+
+msgid "External Registration Clicks"
+msgstr "Cliques de registro externo"
+
 msgid "Hosted by:"
 msgstr "Organizado por:"
 

--- a/frontend/src/locales/pt.po
+++ b/frontend/src/locales/pt.po
@@ -9606,3 +9606,21 @@ msgstr "CEP ou Código postal"
 #: src/components/routes/product-widget/CollectInformation/index.tsx:523
 msgid "ZIP or Postal Code"
 msgstr "CEP ou Código Postal"
+
+msgid "Event Host / Organizer"
+msgstr "Organizador do evento"
+
+msgid "Registration Message"
+msgstr "Mensagem de registo"
+
+msgid "The name of the external platform or organizer hosting the registration"
+msgstr "O nome da plataforma externa ou organizador que aloja o registo"
+
+msgid "The message shown on the event page explaining external registration"
+msgstr "A mensagem mostrada na página do evento explicando o registo externo"
+
+msgid "Hosted by:"
+msgstr "Organizado por:"
+
+msgid "Luma"
+msgstr "Luma"

--- a/frontend/src/locales/pt.po
+++ b/frontend/src/locales/pt.po
@@ -9619,6 +9619,63 @@ msgstr "O nome da plataforma externa ou organizador que aloja o registo"
 msgid "The message shown on the event page explaining external registration"
 msgstr "A mensagem mostrada na página do evento explicando o registo externo"
 
+msgid "Registration Settings"
+msgstr "Definições de registo"
+
+msgid "Configure how attendees register for your event"
+msgstr "Configure como os participantes se registam no seu evento"
+
+msgid "Use external registration"
+msgstr "Usar registo externo"
+
+msgid "Enable this if you're using an external platform like Luma, Eventbrite, or your own registration system"
+msgstr "Ative isto se estiver a usar uma plataforma externa como Luma, Eventbrite ou o seu próprio sistema de registo"
+
+msgid "External Registration URL"
+msgstr "URL de registo externo"
+
+msgid "The URL where attendees will be redirected to register"
+msgstr "O URL para onde os participantes serão redirecionados para se registarem"
+
+msgid "Button Text"
+msgstr "Texto do botão"
+
+msgid "Register on Luma"
+msgstr "Registar no Luma"
+
+msgid "The text shown on the registration button"
+msgstr "O texto mostrado no botão de registo"
+
+msgid "This event uses external registration."
+msgstr "Este evento usa registo externo."
+
+msgid "Note:"
+msgstr "Nota:"
+
+msgid "When external registration is enabled, the ticket selection and checkout will be hidden. Attendees will be redirected to your external registration URL."
+msgstr "Quando o registo externo está ativado, a seleção de bilhetes e o checkout serão ocultados. Os participantes serão redirecionados para o seu URL de registo externo."
+
+msgid "Save Changes"
+msgstr "Guardar alterações"
+
+msgid "Registration settings updated successfully"
+msgstr "Definições de registo atualizadas com sucesso"
+
+msgid "External registration URL is required"
+msgstr "URL de registo externo é obrigatório"
+
+msgid "Please enter a valid URL"
+msgstr "Por favor, insira um URL válido"
+
+msgid "Button text is required"
+msgstr "O texto do botão é obrigatório"
+
+msgid "Register Externally"
+msgstr "Registar externamente"
+
+msgid "External Registration Clicks"
+msgstr "Cliques de registo externo"
+
 msgid "Hosted by:"
 msgstr "Organizado por:"
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -250,6 +250,13 @@ export interface EventSettings {
 
     // Simplified homepage theme settings (new 2-color + mode system)
     homepage_theme_settings?: HomepageThemeSettings;
+
+    // External registration settings
+    is_external_registration?: boolean;
+    external_registration_url?: string;
+    external_registration_button_text?: string;
+    external_registration_message?: string;
+    external_registration_host?: string;
 }
 
 export interface VenueAddress {
@@ -341,6 +348,7 @@ export interface EventDailyStats {
     attendees_registered: number;
     total_refunded: number;
     orders_created: number;
+    external_registration_clicks: number;
 }
 
 export interface CheckInStats {
@@ -364,6 +372,7 @@ export interface EventStats {
     total_fees: number;
     total_views: number;
     total_refunded: number;
+    total_external_registration_clicks: number;
 }
 
 export interface OrganizerStats {

--- a/frontend/src/utilites/analytics.ts
+++ b/frontend/src/utilites/analytics.ts
@@ -20,6 +20,7 @@ export const AnalyticsEvents = {
     PURCHASE_COMPLETED_PAID: 'purchase_completed_paid',
     PURCHASE_COMPLETED_OFFLINE: 'purchase_completed_offline',
     PURCHASE_COMPLETED_FREE: 'purchase_completed_free',
+    EXTERNAL_REGISTRATION_CLICKED: 'external_registration_clicked',
 } as const;
 
 export type AnalyticsEventName = typeof AnalyticsEvents[keyof typeof AnalyticsEvents];


### PR DESCRIPTION
# Feature: External Registration URL Support (#1024)

## 📖 Overview
This PR adds support for **External Registration URLs**, allowing event organizers to redirect attendees to third-party platforms (e.g., Luma, Eventbrite, partner websites) instead of using the internal checkout system. 

Previously, there was no native way to handle events hosted by external partners. Organizers were forced to use workarounds, such as placing links in descriptions, which created user friction. This update enables **Hi.Events** to function as both a full registration platform and an event directory/aggregator.

## 🛠 Changes

### 🟢 Backend
* **Database Migrations:**
    * Added `external_registration_url`, `external_registration_button_text`, `external_registration_message`, and `external_registration_host` to the `event_settings` table.
    * Added `external_registration_clicks` to event statistics tables.
* **Domain & DTOs:**
    * Updated `EventSettingDomainObject`, `EventStatisticDomainObject`, and `EventDailyStatisticDomainObject`.
    * Enhanced DTOs to handle external registration data and click tracking.
* **API Endpoints:**
    * Extended event settings update endpoints to accept new fields.
    * **New Route:** `POST /events/{event_id}/track-external-registration-click`
    * Added `TrackExternalRegistrationClickAction` to handle click tracking logic.
* **Resources:**
    * Updated `EventSettingsResource` and `EventSettingsResourcePublic`.
    * Updated `EventStatisticsResource` to expose click counts.

### 🔵 Frontend
* **Event Settings:**
    * Added a dedicated panel in **Registration Settings**.
    * Includes a toggle to enable/disable external registration.
    * Added validation fields for URL (required), button text (required), custom message, and host name.
    * Added warning notices regarding the behavior change when enabled.
* **Event Homepage:**
    * Replaced the "Get Tickets" flow with a redirect button (opens in a new tab).
    * Hides ticket selection and internal checkout UI.
    * Displays the custom button text (e.g., "Register on Luma") and custom message.
* **Event Card:**
    * Updated CTA to reflect external registration status and text.
* **Analytics:**
    * Integrated "External Registration Clicks" into the daily and overall statistics dashboard.

## 🔄 How It Works
1.  **Configuration:** The organizer navigates to **Event Settings → Registration Settings** and enables "External Registration."
2.  **Setup:** The organizer inputs the external URL, custom button text, and optional host details.
3.  **User Experience:** * The attendee sees the custom CTA on the event page.
    * Clicking the button triggers a tracking event (counting the click).
    * The user is immediately redirected to the external platform in a new tab.
4.  **Tracking:** The organizer views click-through performance in the Statistics Dashboard.

## 📸 Screenshots


1. Dynamic Settings & Menu Enabling external registration automatically hides irrelevant configuration panels (such as Tickets or Coupons) and streamlines the sidebar menu to reduce clutter.

<img width="1909" height="1012" alt="image" src="https://github.com/user-attachments/assets/8a96c3d0-d367-48ff-abb9-93c92acba923" />

2. Management Banner & Metrics A new status banner clearly indicates when an event is managed externally. Note that Metrics and attendee lists are retained to allow for manual imports, ensuring Hi.Events remains the Single Source of Truth (SSOT) for reporting.

<img width="1073" height="401" alt="image" src="https://github.com/user-attachments/assets/784f2ce4-4ead-431e-bd0f-29f8bc027bc3" />


3. Redirection Analytics For external events, a dedicated statistic card appears in the dashboard to track the number of outbound clicks/redirections.

<img width="1606" height="843" alt="image" src="https://github.com/user-attachments/assets/a9b4feb6-1e25-4ab2-aefd-6cabea644894" />

4. Public View

<img width="951" height="576" alt="image" src="https://github.com/user-attachments/assets/c985c263-29ad-4e1a-be1a-731c1170a0e4" />

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.

Thank you for your contribution! 🎉
