### PR TITLE
fix(widget): capture document.currentScript before DOMContentLoaded (#676)

### DIFF
--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -1,5 +1,5 @@
 /* eslint-disable lingui/no-unlocalized-strings */
-(function () {
+(function (scriptElement) {
     const isScriptLoaded = () => !!window.hiEventWidgetLoaded;
 
     const loadWidget = () => {
@@ -7,7 +7,7 @@
 
         let scriptOrigin;
         try {
-            const scriptURL = document.currentScript.src;
+            const scriptURL = scriptElement.src;
             scriptOrigin = new URL(scriptURL).origin;
         } catch (e) {
             console.error('HiEvent widget error: Invalid script URL');
@@ -86,4 +86,4 @@
             loadWidget();
         }
     }
-})();
+})(document.currentScript);


### PR DESCRIPTION
## Problem

When widget.js is loaded in <head> without async, the browser executes the script while the DOM is still parsing (readyState === 'loading'). The IIFE registers a DOMContentLoaded listener and returns. By the time that listener fires, document.currentScript is null, causing a silent crash: `Uncaught TypeError: Cannot read properties of null (reading 'src')`

=> The widget never renders.

## Fix

Capture document.currentScript at IIFE invocation time and pass it as a parameter. The reference remains valid regardless of when loadWidget() is eventually called. No need to put the script in head, you can now put it wherever you want in the body.

I think it can also resolve https://github.com/HiEventsDev/Hi.Events/issues/676

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.