### PR TITLE
Add Laravel scheduler to all-in-one Docker setup

### DIFF
--- a/docker/all-in-one/supervisor/supervisord.conf
+++ b/docker/all-in-one/supervisor/supervisord.conf
@@ -46,3 +46,14 @@ stderr_logfile=/dev/stderr
 redirect_stderr=true
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
+
+[program:laravel-scheduler]
+command=/bin/sh -c "while true; do php /app/backend/artisan schedule:run --no-interaction; sleep 60; done"
+autostart=true
+autorestart=true
+user=www-data
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+redirect_stderr=true
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
Add scheduler process to supervisord in the all-in-one Docker setup so scheduled tasks run automatically.