### PR TITLE
Fix hardcoded database username and DB name in AIO Compose file

### DIFF
--- a/docker/all-in-one/docker-compose.yml
+++ b/docker/all-in-one/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     image: postgres:17-alpine
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-postgres} -d $${POSTGRES_DB:-hi-events}" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fixes the healthcheck command in AIO Docker Compose file so that the DB name and user specified by the environment are used in the healthcheck.

Tested by making this change locally for my deployment Compose file. Fixed the error I was having. Isolated testing probably a good idea since I was tweaking a few things around the same time

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code is of good quality and follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.