### PR TITLE
fix: Validate sort_by parameter against allowlist in repositories

### DIFF
--- a/backend/app/DomainObjects/ProductCategoryDomainObject.php
+++ b/backend/app/DomainObjects/ProductCategoryDomainObject.php
@@ -2,10 +2,40 @@
 
 namespace HiEvents\DomainObjects;
 
+use HiEvents\DomainObjects\Interfaces\IsSortable;
+use HiEvents\DomainObjects\SortingAndFiltering\AllowedSorts;
 use Illuminate\Support\Collection;
 
-class ProductCategoryDomainObject extends Generated\ProductCategoryDomainObjectAbstract
+class ProductCategoryDomainObject extends Generated\ProductCategoryDomainObjectAbstract implements IsSortable
 {
+    public static function getDefaultSort(): string
+    {
+        return self::ORDER;
+    }
+
+    public static function getDefaultSortDirection(): string
+    {
+        return 'asc';
+    }
+
+    public static function getAllowedSorts(): AllowedSorts
+    {
+        return new AllowedSorts([
+            self::ORDER => [
+                'asc' => __('Order Ascending'),
+                'desc' => __('Order Descending'),
+            ],
+            self::CREATED_AT => [
+                'asc' => __('Oldest First'),
+                'desc' => __('Newest First'),
+            ],
+            self::NAME => [
+                'asc' => __('Name A-Z'),
+                'desc' => __('Name Z-A'),
+            ],
+        ]);
+    }
+
     public ?Collection $products = null;
 
     public function setProducts(Collection $products): void

--- a/backend/app/Repository/Eloquent/AffiliateRepository.php
+++ b/backend/app/Repository/Eloquent/AffiliateRepository.php
@@ -44,8 +44,8 @@ class AffiliateRepository extends BaseRepository implements AffiliateRepositoryI
         }
 
         $this->model = $this->model->orderBy(
-            column: $params->sort_by ?? AffiliateDomainObject::getDefaultSort(),
-            direction: $params->sort_direction ?? 'desc',
+            column: $this->validateSortColumn($params->sort_by, AffiliateDomainObject::class),
+            direction: $this->validateSortDirection($params->sort_direction, AffiliateDomainObject::class),
         );
 
         return $this->paginateWhere(

--- a/backend/app/Repository/Eloquent/AttendeeRepository.php
+++ b/backend/app/Repository/Eloquent/AttendeeRepository.php
@@ -85,8 +85,8 @@ class AttendeeRepository extends BaseRepository implements AttendeeRepositoryInt
             $this->applyFilterFields($params, AttendeeDomainObject::getAllowedFilterFields(), prefix: 'attendees');
         }
 
-        $sortBy = $params->sort_by ?? AttendeeDomainObject::getDefaultSort();
-        $sortDirection = $params->sort_direction ?? AttendeeDomainObject::getDefaultSortDirection();
+        $sortBy = $this->validateSortColumn($params->sort_by, AttendeeDomainObject::class);
+        $sortDirection = $this->validateSortDirection($params->sort_direction, AttendeeDomainObject::class);
 
         if ($sortBy === AttendeeDomainObject::TICKET_NAME_SORT_KEY) {
             $this->model = $this->model

--- a/backend/app/Repository/Eloquent/BaseRepository.php
+++ b/backend/app/Repository/Eloquent/BaseRepository.php
@@ -7,6 +7,7 @@ namespace HiEvents\Repository\Eloquent;
 use BadMethodCallException;
 use Carbon\Carbon;
 use HiEvents\DomainObjects\Interfaces\DomainObjectInterface;
+use HiEvents\DomainObjects\Interfaces\IsSortable;
 use HiEvents\Http\DTO\QueryParamsDTO;
 use HiEvents\Models\BaseModel;
 use HiEvents\Repository\Eloquent\Value\Relationship;
@@ -53,6 +54,28 @@ abstract class BaseRepository implements RepositoryInterface
      * @return string
      */
     abstract protected function getModel(): string;
+
+    /**
+     * @param class-string<IsSortable> $domainObjectClass
+     */
+    protected function validateSortColumn(?string $sortBy, string $domainObjectClass): string
+    {
+        $allowedColumns = array_keys($domainObjectClass::getAllowedSorts()->toArray());
+        $default = $domainObjectClass::getDefaultSort();
+
+        if ($sortBy === null || !in_array($sortBy, $allowedColumns, true)) {
+            return $default;
+        }
+
+        return $sortBy;
+    }
+
+    protected function validateSortDirection(?string $sortDirection, string $domainObjectClass): string
+    {
+        return in_array(strtolower($sortDirection ?? ''), ['asc', 'desc'], true)
+            ? $sortDirection
+            : $domainObjectClass::getDefaultSortDirection();
+    }
 
     public function setMaxPerPage(int $maxPerPage): static
     {

--- a/backend/app/Repository/Eloquent/CapacityAssignmentRepository.php
+++ b/backend/app/Repository/Eloquent/CapacityAssignmentRepository.php
@@ -39,8 +39,8 @@ class CapacityAssignmentRepository extends BaseRepository implements CapacityAss
         }
 
         $this->model = $this->model->orderBy(
-            $params->sort_by ?? CapacityAssignmentDomainObject::getDefaultSort(),
-            $params->sort_direction ?? CapacityAssignmentDomainObject::getDefaultSortDirection(),
+            $this->validateSortColumn($params->sort_by, CapacityAssignmentDomainObject::class),
+            $this->validateSortDirection($params->sort_direction, CapacityAssignmentDomainObject::class),
         );
 
         return $this->paginateWhere(

--- a/backend/app/Repository/Eloquent/CheckInListRepository.php
+++ b/backend/app/Repository/Eloquent/CheckInListRepository.php
@@ -140,8 +140,8 @@ class CheckInListRepository extends BaseRepository implements CheckInListReposit
         }
 
         $this->model = $this->model->orderBy(
-            $params->sort_by ?? CheckInListDomainObject::getDefaultSort(),
-            $params->sort_direction ?? CheckInListDomainObject::getDefaultSortDirection(),
+            $this->validateSortColumn($params->sort_by, CheckInListDomainObject::class),
+            $this->validateSortDirection($params->sort_direction, CheckInListDomainObject::class),
         );
 
         return $this->paginateWhere(

--- a/backend/app/Repository/Eloquent/EventRepository.php
+++ b/backend/app/Repository/Eloquent/EventRepository.php
@@ -81,8 +81,8 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
         }
 
         $this->model = $this->model->orderBy(
-            $params->sort_by ?? EventDomainObject::getDefaultSort(),
-            $params->sort_direction ?? EventDomainObject::getDefaultSortDirection(),
+            $this->validateSortColumn($params->sort_by, EventDomainObject::class),
+            $this->validateSortDirection($params->sort_direction, EventDomainObject::class),
         );
 
         return $this->paginateWhere(

--- a/backend/app/Repository/Eloquent/MessageRepository.php
+++ b/backend/app/Repository/Eloquent/MessageRepository.php
@@ -46,8 +46,8 @@ class MessageRepository extends BaseRepository implements MessageRepositoryInter
         }
 
         $this->model = $this->model->orderBy(
-            $params->sort_by ?? MessageDomainObject::getDefaultSort(),
-            $params->sort_direction ?? 'desc',
+            $this->validateSortColumn($params->sort_by, MessageDomainObject::class),
+            $this->validateSortDirection($params->sort_direction, MessageDomainObject::class),
         );
 
         return $this->paginateWhere(

--- a/backend/app/Repository/Eloquent/OrderRepository.php
+++ b/backend/app/Repository/Eloquent/OrderRepository.php
@@ -57,8 +57,8 @@ class OrderRepository extends BaseRepository implements OrderRepositoryInterface
         }
 
         $this->model = $this->model->orderBy(
-            column: $params->sort_by ?? OrderDomainObject::getDefaultSort(),
-            direction: $params->sort_direction ?? 'desc',
+            column: $this->validateSortColumn($params->sort_by, OrderDomainObject::class),
+            direction: $this->validateSortDirection($params->sort_direction, OrderDomainObject::class),
         );
 
         return $this->paginateWhere(
@@ -102,9 +102,10 @@ class OrderRepository extends BaseRepository implements OrderRepositoryInterface
             ->where('events.organizer_id', $organizerId)
             ->where('events.account_id', $accountId);
 
+        $sortBy = $this->validateSortColumn($params->sort_by, OrderDomainObject::class);
         $this->model = $this->model->orderBy(
-            column: $params->sort_by ? 'orders.' . $params->sort_by : 'orders.' . OrderDomainObject::getDefaultSort(),
-            direction: $params->sort_direction ?? 'desc',
+            column: 'orders.' . $sortBy,
+            direction: $this->validateSortDirection($params->sort_direction, OrderDomainObject::class),
         );
 
         return $this->paginateWhere(

--- a/backend/app/Repository/Eloquent/ProductCategoryRepository.php
+++ b/backend/app/Repository/Eloquent/ProductCategoryRepository.php
@@ -36,10 +36,10 @@ class ProductCategoryRepository extends BaseRepository implements ProductCategor
             }
         }
 
-        // Apply sorting from QueryParamsDTO
-        if (!empty($queryParamsDTO->sort_by)) {
-            $query->orderBy($queryParamsDTO->sort_by, $queryParamsDTO->sort_direction ?? 'asc');
-        }
+        $query->orderBy(
+            $this->validateSortColumn($queryParamsDTO->sort_by, ProductCategoryDomainObject::class),
+            $this->validateSortDirection($queryParamsDTO->sort_direction, ProductCategoryDomainObject::class),
+        );
 
         return $query->get();
     }

--- a/backend/app/Repository/Eloquent/ProductRepository.php
+++ b/backend/app/Repository/Eloquent/ProductRepository.php
@@ -41,8 +41,8 @@ class ProductRepository extends BaseRepository implements ProductRepositoryInter
         }
 
         $this->model = $this->model->orderBy(
-            $params->sort_by ?? ProductDomainObject::getDefaultSort(),
-            $params->sort_direction ?? ProductDomainObject::getDefaultSortDirection(),
+            $this->validateSortColumn($params->sort_by, ProductDomainObject::class),
+            $this->validateSortDirection($params->sort_direction, ProductDomainObject::class),
         );
 
         return $this->paginateWhere(

--- a/backend/app/Repository/Eloquent/PromoCodeRepository.php
+++ b/backend/app/Repository/Eloquent/PromoCodeRepository.php
@@ -39,8 +39,8 @@ class PromoCodeRepository extends BaseRepository implements PromoCodeRepositoryI
         }
 
         $this->model = $this->model->orderBy(
-            column: $params->sort_by ?? PromoCodeDomainObject::getDefaultSort(),
-            direction: $params->sort_direction ?? 'desc',
+            column: $this->validateSortColumn($params->sort_by, PromoCodeDomainObject::class),
+            direction: $this->validateSortDirection($params->sort_direction, PromoCodeDomainObject::class),
         );
 
         return $this->paginateWhere(

--- a/backend/app/Repository/Eloquent/WaitlistEntryRepository.php
+++ b/backend/app/Repository/Eloquent/WaitlistEntryRepository.php
@@ -156,8 +156,8 @@ class WaitlistEntryRepository extends BaseRepository implements WaitlistEntryRep
         }
 
         $this->model = $this->model->orderBy(
-            column: $params->sort_by ?? WaitlistEntryDomainObject::getDefaultSort(),
-            direction: $params->sort_direction ?? WaitlistEntryDomainObject::getDefaultSortDirection(),
+            column: $this->validateSortColumn($params->sort_by, WaitlistEntryDomainObject::class),
+            direction: $this->validateSortDirection($params->sort_direction, WaitlistEntryDomainObject::class),
         );
 
         return $this->loadRelation(new Relationship(


### PR DESCRIPTION
## Summary

- Multiple repository classes were passing the user-supplied `sort_by` query parameter directly to Eloquent's `orderBy()` without validation, enabling SQL injection (PostgreSQL supports stacked queries, so this is particularly spicy)
- Added `validateSortColumn()` and `validateSortDirection()` helpers to `BaseRepository` that check against each domain object's existing `getAllowedSorts()` whitelist
- Applied validation across all 11 affected repository files — invalid values silently fall back to defaults
- Added `IsSortable` to `ProductCategoryDomainObject` (the one domain object that was missing it)

The allowlist pattern was already used correctly in the admin endpoints (`getAllEventsForAdmin`, `getAllOrdersForAdmin`) — this just applies the same approach everywhere else.

## Test plan

- [x] All 350 unit tests pass
- [x] Verify sorting still works on attendees, orders, events, promo codes, etc.
- [x] Confirm invalid `sort_by` values fall back to defaults instead of erroring

Reported by @tikket1