### PR TITLE
fix: Preserve image dimensions on save in rich text editor

### DIFF
--- a/frontend/src/components/common/Editor/Extensions/ImageResizeExtension/index.tsx
+++ b/frontend/src/components/common/Editor/Extensions/ImageResizeExtension/index.tsx
@@ -17,6 +17,9 @@ export const ImageResize = Image.extend({
                         ? `width: ${width}px; height: auto; cursor: pointer;`
                         : `${element.style.cssText}`;
                 },
+                renderHTML: (attributes: Record<string, string>) => {
+                    return { style: attributes.style };
+                },
             },
         };
     },


### PR DESCRIPTION
## Human Summary
_I'm working with the system locally for fun. I noticed that whenever I save an image that's been resized, the system "forgets" the resizing and displays it full width in a giant image upon subsequent edits.  Claude code helped me diagnose and fix the code as detailed further below.  Sharing with you in case it helps others. Please let me know if helpful or not as I'm new to open source and I don't want to be a bother if not useful.  (I have a couple of other fixes/improvements I could share if interested).  Thanks!

## AI Summary

  Fixes a bug where resized images in the TipTap rich text editor (event homepage, email
  templates) revert to full width on subsequent saves.

  **Root cause:** The `ImageResize` extension defines `parseHTML` for the `style` attribute
  but not `renderHTML`, so image dimensions are silently dropped during HTML serialization via
   `getHTML()`. On reload, `parseHTML` finds no style and defaults to `width: 100%`.

  **Fix:** Add `renderHTML` to output the `style` attribute on `<img>` tags, preserving
  dimensions across save/load cycles.

  ## Steps to reproduce (before fix)

  1. Edit an event homepage or email template
  2. Insert an image and resize it using the drag handles
  3. Save — image appears correctly sized
  4. Edit and save again (or reload the page) — image reverts to 100% width

  ## Test plan

  - [ ] Insert an image into the editor and resize it
  - [ ] Save, reload, verify dimensions persist
  - [ ] Edit the page again, save again, verify dimensions still persist
  - [ ] Verify newly inserted images still default to full width
  - [ ] Verify resize drag handles still work correctly after the fix