### PR TITLE
test: BaseRepository coverage + hermetic test DB infrastructure

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,9 +5,11 @@ on:
     branches: [main, develop]
     paths:
       - 'backend/**'
+      - '.github/workflows/unit-tests.yml'
   pull_request:
     paths:
       - 'backend/**'
+      - '.github/workflows/unit-tests.yml'
 
 jobs:
   run-tests:
@@ -17,6 +19,31 @@ jobs:
       matrix:
         php-versions: ['8.2', '8.3', '8.4']
 
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: hievents_test
+          POSTGRES_USER: hievents
+          POSTGRES_PASSWORD: hievents
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U hievents -d hievents_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    # Job-level env. .env.testing supplies the rest, but the DB host on a CI
+    # runner is 127.0.0.1 (service container exposes its port on the runner),
+    # not the docker network alias used locally — override here.
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_DATABASE: hievents_test
+      DB_USERNAME: hievents
+      DB_PASSWORD: hievents
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -25,7 +52,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, xml, ctype, iconv, intl, pdo, pdo_mysql, tokenizer
+          extensions: mbstring, xml, ctype, iconv, intl, pdo, pdo_mysql, pdo_pgsql, pgsql, tokenizer
           ini-values: post_max_size=256M, upload_max_filesize=256M
           coverage: none
 
@@ -46,6 +73,23 @@ jobs:
 
       - name: Install dependencies
         run: cd backend && composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Stage .env for testing
+        # Laravel auto-loads .env.testing when APP_ENV=testing, but artisan
+        # commands run outside that flow read .env directly. Copy .env.testing
+        # to .env so both paths see the same config.
+        run: cp backend/.env.testing backend/.env
+
+      - name: Wait for Postgres
+        run: |
+          for i in {1..30}; do
+            if pg_isready -h 127.0.0.1 -p 5432 -U hievents -d hievents_test; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Postgres did not become ready in time" >&2
+          exit 1
 
       - name: Run PHPUnit Tests
         run: cd backend && ./vendor/bin/phpunit tests/Unit --no-coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,8 @@ cd docker/development
 - **DON'T** use `RefreshDatabase` - use `DatabaseTransactions` instead
 - Unit tests extend Laravel's TestCase, not PHPUnit's TestCase
 - Use Mockery for mocking
+- Tests run against a dedicated `hievents_test` database, configured via `backend/.env.testing` and enforced by `phpunit.xml`. The local docker-compose creates this database automatically via `docker/development/pgsql-init/`. If your existing pgsql volume predates this script, create the DB once with: `docker compose -f docker-compose.dev.yml exec pgsql psql -U username -d backend -c 'CREATE DATABASE hievents_test OWNER username;'`
+- Database name **must end in `_test`**. Enforced globally by a `final` guard in `tests/TestCase.php::guardAgainstNonTestDatabase()` which runs on every test that boots Laravel — no per-test opt-in needed and no way to bypass.
 
 ### Frontend
 

--- a/backend/.env.testing
+++ b/backend/.env.testing
@@ -1,0 +1,43 @@
+# Auto-loaded by Laravel when APP_ENV=testing (i.e. whenever PHPUnit runs).
+# Safe to commit — contains only test-only credentials and fixed test secrets.
+# Real secrets must NEVER be added here.
+
+APP_NAME=Hi.Events
+APP_ENV=testing
+# Static, test-only AES-256 key. Do not reuse outside tests.
+APP_KEY=base64:rasMRv+Gm0oDMcBq+j9MvRgR3a6JYPTZjpRD4rGG2wA=
+APP_DEBUG=true
+APP_URL=http://localhost
+APP_FRONTEND_URL=http://localhost
+APP_LOG_QUERIES=false
+APP_SAAS_MODE_ENABLED=false
+
+LOG_CHANNEL=stderr
+LOG_LEVEL=debug
+
+# Database — must end in _test (BaseRepositoryTest enforces this).
+# CI exports overrides via the workflow; locally these defaults match the
+# docker-compose pgsql service.
+DB_CONNECTION=pgsql
+DB_HOST=pgsql
+DB_PORT=5432
+DB_DATABASE=hievents_test
+DB_USERNAME=username
+DB_PASSWORD=password
+
+# Stateless drivers — keep tests hermetic, no external dependencies.
+BROADCAST_DRIVER=log
+CACHE_DRIVER=array
+FILESYSTEM_PUBLIC_DISK=local
+FILESYSTEM_PRIVATE_DISK=local
+QUEUE_CONNECTION=sync
+SESSION_DRIVER=array
+SESSION_LIFETIME=120
+MAIL_MAILER=array
+
+# Fixed test JWT secret — do not reuse outside tests.
+JWT_SECRET=test-jwt-secret-not-for-production-use-only-in-tests-aaaaaaaaaa
+JWT_ALGO=HS256
+
+BCRYPT_ROUNDS=4
+TELESCOPE_ENABLED=false

--- a/backend/app/Repository/Eloquent/BaseRepository.php
+++ b/backend/app/Repository/Eloquent/BaseRepository.php
@@ -6,6 +6,7 @@ namespace HiEvents\Repository\Eloquent;
 
 use BadMethodCallException;
 use Carbon\Carbon;
+use Closure;
 use HiEvents\DomainObjects\Interfaces\DomainObjectInterface;
 use HiEvents\DomainObjects\Interfaces\IsSortable;
 use HiEvents\Http\DTO\QueryParamsDTO;
@@ -18,6 +19,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Foundation\Application;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
@@ -26,6 +28,7 @@ use TypeError;
 
 /**
  * @template T of DomainObjectInterface
+ *
  * @implements RepositoryInterface<T>
  */
 abstract class BaseRepository implements RepositoryInterface
@@ -50,20 +53,18 @@ abstract class BaseRepository implements RepositoryInterface
 
     /**
      * Returns a FQCL of the model
-     *
-     * @return string
      */
     abstract protected function getModel(): string;
 
     /**
-     * @param class-string<IsSortable> $domainObjectClass
+     * @param  class-string<IsSortable>  $domainObjectClass
      */
     protected function validateSortColumn(?string $sortBy, string $domainObjectClass): string
     {
         $allowedColumns = array_keys($domainObjectClass::getAllowedSorts()->toArray());
         $default = $domainObjectClass::getDefaultSort();
 
-        if ($sortBy === null || !in_array($sortBy, $allowedColumns, true)) {
+        if ($sortBy === null || ! in_array($sortBy, $allowedColumns, true)) {
             return $default;
         }
 
@@ -86,61 +87,63 @@ abstract class BaseRepository implements RepositoryInterface
 
     public function all(array $columns = self::DEFAULT_COLUMNS): Collection
     {
-        $models = $this->model->all($columns);
-        $this->resetModel();
-
-        return $this->handleResults($models);
+        return $this->runQuery(
+            fn () => $this->handleResults($this->model->all($columns))
+        );
     }
 
     public function paginate(
-        ?int  $limit = null,
+        ?int $limit = null,
         array $columns = self::DEFAULT_COLUMNS
-    ): LengthAwarePaginator
-    {
-        $results = $this->model->paginate($this->getPaginationPerPage($limit), $columns);
-        $this->resetModel();
-
-        return $this->handleResults($results);
+    ): LengthAwarePaginator {
+        return $this->runQuery(
+            fn () => $this->handleResults(
+                $this->model->paginate($this->getPaginationPerPage($limit), $columns)
+            )
+        );
     }
 
     public function paginateWhere(
         array $where,
-        ?int  $limit = null,
+        ?int $limit = null,
         array $columns = self::DEFAULT_COLUMNS,
-        ?int  $page = null,
-    ): LengthAwarePaginator
-    {
-        $this->applyConditions($where);
-        $results = $this->model->paginate(
-            perPage: $this->getPaginationPerPage($limit),
-            columns: $columns,
-            page: $page,
-        );
-        $this->resetModel();
+        ?int $page = null,
+    ): LengthAwarePaginator {
+        return $this->runQuery(function () use ($where, $limit, $columns, $page) {
+            $this->applyConditions($where);
 
-        return $this->handleResults($results);
+            return $this->handleResults($this->model->paginate(
+                perPage: $this->getPaginationPerPage($limit),
+                columns: $columns,
+                page: $page,
+            ));
+        });
     }
 
     public function simplePaginateWhere(
         array $where,
-        ?int  $limit = null,
+        ?int $limit = null,
         array $columns = self::DEFAULT_COLUMNS,
-    ): Paginator
-    {
-        $this->applyConditions($where);
-        $results = $this->model->simplePaginate($this->getPaginationPerPage($limit), $columns);
-        $this->resetModel();
+    ): Paginator {
+        return $this->runQuery(function () use ($where, $limit, $columns) {
+            $this->applyConditions($where);
 
-        return $this->handleResults($results);
+            return $this->handleResults(
+                $this->model->simplePaginate($this->getPaginationPerPage($limit), $columns)
+            );
+        });
     }
 
     public function paginateEloquentRelation(
         Relation $relation,
-        ?int     $limit = null,
-        array    $columns = self::DEFAULT_COLUMNS
-    ): LengthAwarePaginator
-    {
-        return $this->handleResults($relation->paginate($this->getPaginationPerPage($limit), $columns));
+        ?int $limit = null,
+        array $columns = self::DEFAULT_COLUMNS
+    ): LengthAwarePaginator {
+        return $this->runQuery(
+            fn () => $this->handleResults(
+                $relation->paginate($this->getPaginationPerPage($limit), $columns)
+            )
+        );
     }
 
     /**
@@ -148,101 +151,94 @@ abstract class BaseRepository implements RepositoryInterface
      */
     public function findById(int $id, array $columns = self::DEFAULT_COLUMNS): DomainObjectInterface
     {
-        $model = $this->model->findOrFail($id, $columns);
-        $this->resetModel();
-
-        return $this->handleSingleResult($model);
+        return $this->runQuery(
+            fn () => $this->handleSingleResult($this->model->findOrFail($id, $columns))
+        );
     }
 
     public function findFirstByField(
-        string  $field,
+        string $field,
         ?string $value = null,
-        array   $columns = ['*']
-    ): ?DomainObjectInterface
-    {
-        $model = $this->model->where($field, '=', $value)->first($columns);
-        $this->resetModel();
-
-        return $this->handleSingleResult($model);
+        array $columns = ['*']
+    ): ?DomainObjectInterface {
+        return $this->runQuery(
+            fn () => $this->handleSingleResult(
+                $this->model->where($field, '=', $value)->first($columns)
+            )
+        );
     }
 
     public function findFirst(int $id, array $columns = self::DEFAULT_COLUMNS): ?DomainObjectInterface
     {
-        $model = $this->model->findOrFail($id, $columns);
-        $this->resetModel();
-
-        return $this->handleSingleResult($model);
+        return $this->runQuery(
+            fn () => $this->handleSingleResult($this->model->findOrFail($id, $columns))
+        );
     }
 
     public function findWhere(
         array $where,
         array $columns = self::DEFAULT_COLUMNS,
         array $orderAndDirections = [],
-    ): Collection
-    {
-        $this->applyConditions($where);
+    ): Collection {
+        return $this->runQuery(function () use ($where, $columns, $orderAndDirections) {
+            $this->applyConditions($where);
 
-        if ($orderAndDirections) {
             foreach ($orderAndDirections as $orderAndDirection) {
                 $this->model = $this->model->orderBy(
                     $orderAndDirection->getOrder(),
                     $orderAndDirection->getDirection()
                 );
             }
-        }
 
-        $model = $this->model->get($columns);
-
-        $this->resetModel();
-
-        return $this->handleResults($model);
+            return $this->handleResults($this->model->get($columns));
+        });
     }
 
     public function findFirstWhere(array $where, array $columns = self::DEFAULT_COLUMNS): ?DomainObjectInterface
     {
-        $this->applyConditions($where);
-        $model = $this->model->first($columns);
-        $this->resetModel();
+        return $this->runQuery(function () use ($where, $columns) {
+            $this->applyConditions($where);
 
-        return $this->handleSingleResult($model);
+            return $this->handleSingleResult($this->model->first($columns));
+        });
     }
 
     public function findWhereIn(string $field, array $values, array $additionalWhere = [], array $columns = self::DEFAULT_COLUMNS): Collection
     {
-        if ($additionalWhere) {
-            $this->applyConditions($additionalWhere);
-        }
+        return $this->runQuery(function () use ($field, $values, $additionalWhere, $columns) {
+            if ($additionalWhere) {
+                $this->applyConditions($additionalWhere);
+            }
 
-        $model = $this->model->whereIn($field, $values)->get($columns);
-        $this->resetModel();
-
-        return $this->handleResults($model);
+            return $this->handleResults($this->model->whereIn($field, $values)->get($columns));
+        });
     }
 
     public function create(array $attributes): DomainObjectInterface
     {
-        $model = $this->model->newInstance(collect($attributes)->toArray());
-        $model->save();
-        $this->resetModel();
+        return $this->runQuery(function () use ($attributes) {
+            $model = $this->model->newInstance(collect($attributes)->toArray());
+            $model->save();
 
-        return $this->handleSingleResult($model);
+            return $this->handleSingleResult($model);
+        });
     }
 
     public function insert(array $inserts): bool
     {
-        // When doing a bulk insert Eloquent doesn't autofill the updated/created dates,
-        // so we need to do it manually
-        foreach ($inserts as $index => $insert) {
-            if (!isset($insert['created_at'], $insert['updated_at'])) {
-                $now = Carbon::now();
-                $inserts[$index]['created_at'] = $now;
-                $inserts[$index]['updated_at'] = $now;
+        return $this->runQuery(function () use ($inserts) {
+            // When doing a bulk insert Eloquent doesn't autofill the updated/created dates,
+            // so we need to do it manually
+            foreach ($inserts as $index => $insert) {
+                if (! isset($insert['created_at'], $insert['updated_at'])) {
+                    $now = Carbon::now();
+                    $inserts[$index]['created_at'] = $now;
+                    $inserts[$index]['updated_at'] = $now;
+                }
             }
-        }
-        $insert = $this->model->insert($inserts);
-        $this->resetModel();
 
-        return $insert;
+            return $this->model->insert($inserts);
+        });
     }
 
     public function updateFromDomainObject(int $id, DomainObjectInterface $domainObject): DomainObjectInterface
@@ -252,93 +248,103 @@ abstract class BaseRepository implements RepositoryInterface
 
     public function updateFromArray(int $id, array $attributes): DomainObjectInterface
     {
-        $model = $this->model->findOrFail($id);
-        $model->fill($attributes);
-        $model->save();
-        $this->resetModel();
+        return $this->runQuery(function () use ($id, $attributes) {
+            $model = $this->model->findOrFail($id);
+            $model->fill($attributes);
+            $model->save();
 
-        return $this->handleSingleResult($model);
+            return $this->handleSingleResult($model);
+        });
     }
 
     public function updateWhere(array $attributes, array $where): int
     {
-        $this->applyConditions($where);
-        $count = $this->model->update($attributes);
-        $this->resetModel();
+        return $this->runQuery(function () use ($attributes, $where) {
+            $this->applyConditions($where);
 
-        return $count;
+            return $this->model->update($attributes);
+        });
     }
 
     public function updateByIdWhere(int $id, array $attributes, array $where): DomainObjectInterface
     {
-        $model = $this->model->where($where)->findOrFail($id);
-        $model->update($attributes);
-        $this->resetModel();
+        return $this->runQuery(function () use ($id, $attributes, $where) {
+            $model = $this->model->where($where)->findOrFail($id);
+            $model->update($attributes);
 
-        return $this->handleSingleResult($model);
+            return $this->handleSingleResult($model);
+        });
     }
 
     public function deleteById(int $id): bool
     {
-        return $this->model->findOrFail($id)->delete();
+        return $this->runQuery(
+            fn () => (bool) $this->model->findOrFail($id)->delete()
+        );
     }
 
     public function incrementEach(array $columns, array $additionalUpdates = [], ?array $where = null): int
     {
-        if ($where) {
-            $this->applyConditions($where);
-        }
+        return $this->runQuery(function () use ($columns, $additionalUpdates, $where) {
+            if ($where) {
+                $this->applyConditions($where);
+            }
 
-        $count = $this->model->incrementEach($columns, $additionalUpdates);
-        $this->resetModel();
-
-        return $count;
+            // Eloquent\Builder's __call swallows incrementEach's int return value
+            // and hands back the Builder, so we route through the underlying
+            // QueryBuilder to get the affected-row count.
+            return $this->resolveBaseQuery()->incrementEach($columns, $additionalUpdates);
+        });
     }
 
     public function decrementEach(array $where, array $columns, array $extra = []): int
     {
-        $this->applyConditions($where);
-        $count = $this->model->decrementEach($columns, $extra);
-        $this->resetModel();
+        return $this->runQuery(function () use ($where, $columns, $extra) {
+            $this->applyConditions($where);
 
-        return $count;
+            return $this->resolveBaseQuery()->decrementEach($columns, $extra);
+        });
     }
 
     public function increment(int|float $id, string $column, int|float $amount = 1): int
     {
-        return $this->model->findOrFail($id)->increment($column, $amount);
+        return $this->runQuery(
+            fn () => $this->model->findOrFail($id)->increment($column, $amount)
+        );
     }
 
     public function incrementWhere(array $where, string $column, int|float $amount = 1): int
     {
-        $this->applyConditions($where);
-        $count = $this->model->increment($column, $amount);
-        $this->resetModel();
+        return $this->runQuery(function () use ($where, $column, $amount) {
+            $this->applyConditions($where);
 
-        return $count;
+            return $this->model->increment($column, $amount);
+        });
     }
 
     public function decrement(int|float $id, string $column, int|float $amount = 1): int
     {
-        return $this->model->findOrFail($id)?->decrement($column, $amount);
+        return $this->runQuery(
+            fn () => $this->model->findOrFail($id)->decrement($column, $amount)
+        );
     }
 
     public function deleteWhere(array $conditions): int
     {
-        $this->applyConditions($conditions);
-        $deleted = $this->model->delete();
-        $this->resetModel();
+        return $this->runQuery(function () use ($conditions) {
+            $this->applyConditions($conditions);
 
-        return $deleted;
+            return $this->model->delete();
+        });
     }
 
     public function countWhere(array $conditions): int
     {
-        $this->applyConditions($conditions);
-        $count = $this->model->count();
-        $this->resetModel();
+        return $this->runQuery(function () use ($conditions) {
+            $this->applyConditions($conditions);
 
-        return $count;
+            return $this->model->count();
+        });
     }
 
     public function loadRelation(string|Relationship $relationship): static
@@ -363,7 +369,7 @@ abstract class BaseRepository implements RepositoryInterface
     protected function applyConditions(array $where): void
     {
         foreach ($where as $field => $value) {
-            if (is_callable($value) && !is_string($value)) {
+            if (is_callable($value) && ! is_string($value)) {
                 $this->model = $this->model->where($value);
             } elseif (is_array($value)) {
                 [$field, $condition, $val] = $value;
@@ -406,6 +412,48 @@ abstract class BaseRepository implements RepositoryInterface
         return $this->app->make($model ?: $this->getModel());
     }
 
+    /**
+     * Execute a query callback and guarantee per-call state is reset afterwards,
+     * even if the callback throws. This is the single point at which the in-flight
+     * builder ($this->model) and the eager-load list ($this->eagerLoads) are cleared.
+     *
+     * The callback runs BEFORE reset, so hydration helpers that read $this->eagerLoads
+     * (e.g. handleEagerLoads()) still see the correct state.
+     *
+     * @template TReturn
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    protected function runQuery(Closure $callback): mixed
+    {
+        try {
+            return $callback();
+        } finally {
+            $this->resetState();
+        }
+    }
+
+    protected function resetState(): void
+    {
+        $model = $this->getModel();
+        $this->model = new $model;
+        $this->eagerLoads = [];
+    }
+
+    /**
+     * Resolve $this->model (which may be a fresh Model or an Eloquent Builder
+     * after applyConditions()) to the underlying query builder. Required for
+     * methods Eloquent\Builder::__call swallows the return value of, e.g.
+     * incrementEach() / decrementEach().
+     */
+    private function resolveBaseQuery(): QueryBuilder
+    {
+        return $this->model instanceof Builder
+            ? $this->model->getQuery()
+            : $this->model->newQuery()->getQuery();
+    }
+
     protected function handleResults($results, ?string $domainObjectOverride = null)
     {
         $domainObjects = [];
@@ -428,10 +476,9 @@ abstract class BaseRepository implements RepositoryInterface
 
     protected function handleSingleResult(
         ?BaseModel $model,
-        ?string    $domainObjectOverride = null
-    ): ?DomainObjectInterface
-    {
-        if (!$model) {
+        ?string $domainObjectOverride = null
+    ): ?DomainObjectInterface {
+        if (! $model) {
             return null;
         }
 
@@ -442,11 +489,10 @@ abstract class BaseRepository implements RepositoryInterface
         QueryParamsDTO $params,
         array $allowedFilterFields = [],
         ?string $prefix = null,
-    ): void
-    {
+    ): void {
         if ($params->filter_fields && $params->filter_fields->isNotEmpty()) {
             $params->filter_fields->each(function ($filterField) use ($prefix, $allowedFilterFields) {
-                if (!in_array($filterField->field, $allowedFilterFields, true)) {
+                if (! in_array($filterField->field, $allowedFilterFields, true)) {
                     return;
                 }
 
@@ -467,7 +513,7 @@ abstract class BaseRepository implements RepositoryInterface
                     sprintf('Operator %s is not supported', $filterField->operator)
                 );
 
-                $field = $prefix ? $prefix . '.' . $filterField->field : $filterField->field;
+                $field = $prefix ? $prefix.'.'.$filterField->field : $filterField->field;
 
                 // Special handling for IN operator
                 if ($operator === 'IN') {
@@ -491,10 +537,13 @@ abstract class BaseRepository implements RepositoryInterface
         }
     }
 
+    /**
+     * @deprecated Use resetState() instead. Kept for backwards compatibility with
+     *             subclass repositories that build custom queries on $this->model.
+     */
     protected function resetModel(): void
     {
-        $model = $this->getModel();
-        $this->model = new $model();
+        $this->resetState();
     }
 
     private function getPaginationPerPage(?int $perPage): int
@@ -503,30 +552,26 @@ abstract class BaseRepository implements RepositoryInterface
             $perPage = self::DEFAULT_PAGINATE_LIMIT;
         }
 
-        return (int)min($perPage, $this->maxPerPage);
+        return (int) min($perPage, $this->maxPerPage);
     }
 
     /**
-     * @param Model $model
-     * @param string|null $domainObjectOverride A FQCN of a DO
-     * @param array|null $relationships
-     * @return DomainObjectInterface
+     * @param  string|null  $domainObjectOverride  A FQCN of a DO
      *
      * @todo use hydrate method from AbstractDomainObject
      */
     private function hydrateDomainObjectFromModel(
-        Model   $model,
+        Model $model,
         ?string $domainObjectOverride = null,
-        ?array  $relationships = null,
-    ): DomainObjectInterface
-    {
+        ?array $relationships = null,
+    ): DomainObjectInterface {
         /** @var DomainObjectInterface $object */
         $object = $domainObjectOverride ?: $this->getDomainObject();
-        $object = new $object();
+        $object = new $object;
 
         foreach ($model->attributesToArray() as $attribute => $value) {
-            $method = 'set' . ucfirst(Str::camel($attribute));
-            if (is_callable(array($object, $method))) {
+            $method = 'set'.Str::studly($attribute);
+            if (is_callable([$object, $method])) {
                 try {
                     $object->$method($value);
                 } catch (TypeError $e) {
@@ -538,7 +583,7 @@ abstract class BaseRepository implements RepositoryInterface
                             var_export($value, true),
                             $e->getMessage()
                         ),
-                        (int)$e->getCode(),
+                        (int) $e->getCode(),
                         $e
                     );
                 }
@@ -554,24 +599,20 @@ abstract class BaseRepository implements RepositoryInterface
     /**
      * This method will handle nested eager loading of relationships
      *
-     * @param Model $model
-     * @param DomainObjectInterface $object
-     * @param Relationship[]|null $relationships
-     *
-     * @return void
+     * @param  Relationship[]|null  $relationships
      */
     private function handleEagerLoads(Model $model, DomainObjectInterface $object, ?array $relationships): void
     {
         $eagerLoads = $relationships ?: $this->eagerLoads;
 
         foreach ($eagerLoads as $eagerLoad) {
-            if (!$model->relationLoaded($eagerLoad->getName())) {
+            if (! $model->relationLoaded($eagerLoad->getName())) {
                 continue;
             }
             $relatedModels = $model->getRelation($eagerLoad->getName());
-            $setterMethod = 'set' . Str::studly($eagerLoad->getName());
+            $setterMethod = 'set'.Str::studly($eagerLoad->getName());
 
-            if (!is_callable([$object, $setterMethod])) {
+            if (! is_callable([$object, $setterMethod])) {
                 throw new BadMethodCallException(
                     sprintf(
                         'Method %s is not callable on %s. Does it exist?',
@@ -590,7 +631,7 @@ abstract class BaseRepository implements RepositoryInterface
                     );
                 });
                 $object->$setterMethod($relatedDomainObjects);
-            } else if ($relatedModels instanceof BaseModel) {
+            } elseif ($relatedModels instanceof BaseModel) {
                 $relatedDomainObject = $this->hydrateDomainObjectFromModel(
                     $relatedModels,
                     $eagerLoad->getDomainObject(),

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -22,7 +22,7 @@
         <env name="APP_URL" value="http://localhost"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-<!--        <env name="DB_DATABASE" value="testing"/>-->
+        <env name="DB_DATABASE" value="hievents_test" force="true"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -3,8 +3,45 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use RuntimeException;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->guardAgainstNonTestDatabase();
+    }
+
+    /**
+     * Hard safety net: any test that boots Laravel could (intentionally or not)
+     * issue queries against the configured database. Refuse to run unless the
+     * default connection's database name ends in "_test" so a misconfigured
+     * environment can never touch a dev/staging/prod database.
+     *
+     * The check reads config only — it does not open a connection — so tests
+     * that never touch the database still pay only a constant-time cost and
+     * never fail because the test database is unreachable.
+     *
+     * Marked final so individual tests cannot bypass it.
+     */
+    final protected function guardAgainstNonTestDatabase(): void
+    {
+        $defaultConnection = config('database.default');
+        $database = config("database.connections.{$defaultConnection}.database");
+
+        if (! is_string($database) || ! str_ends_with($database, '_test')) {
+            throw new RuntimeException(sprintf(
+                'Refusing to run %s: default database connection "%s" points at "%s", '
+                .'which does not end in "_test". Set DB_DATABASE to a *_test database '
+                .'(CI uses hievents_test; locally configured via backend/.env.testing).',
+                static::class,
+                (string) $defaultConnection,
+                (string) $database,
+            ));
+        }
+    }
 }

--- a/backend/tests/Unit/Repository/BaseRepositoryTest.php
+++ b/backend/tests/Unit/Repository/BaseRepositoryTest.php
@@ -1,0 +1,725 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Repository;
+
+use HiEvents\Repository\Eloquent\Value\OrderAndDirection;
+use HiEvents\Repository\Eloquent\Value\Relationship;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+use Tests\Unit\Repository\Fixtures\WidgetCategoryDomainObject;
+use Tests\Unit\Repository\Fixtures\WidgetCategoryModel;
+use Tests\Unit\Repository\Fixtures\WidgetCategoryRepository;
+use Tests\Unit\Repository\Fixtures\WidgetDomainObject;
+use Tests\Unit\Repository\Fixtures\WidgetModel;
+use Tests\Unit\Repository\Fixtures\WidgetRepository;
+
+/**
+ * Exercises HiEvents\Repository\Eloquent\BaseRepository against an isolated
+ * fixture schema (br_test_widgets / br_test_widget_categories) so the test is
+ * decoupled from production tables.
+ *
+ * Tables are created in setUp() and dropped in tearDown(). The DatabaseTransactions
+ * trait wraps each test in a transaction, so any data inserted is rolled back too.
+ */
+class BaseRepositoryTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private WidgetRepository $repository;
+
+    private WidgetCategoryRepository $categoryRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('br_test_widget_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('br_test_widgets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->nullable();
+            $table->string('name');
+            $table->string('sku')->nullable();
+            $table->integer('quantity')->default(0);
+            $table->decimal('price', 10, 2)->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->text('description')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        $this->repository = $this->app->make(WidgetRepository::class);
+        $this->categoryRepository = $this->app->make(WidgetCategoryRepository::class);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('br_test_widgets');
+        Schema::dropIfExists('br_test_widget_categories');
+
+        parent::tearDown();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function makeCategory(string $name = 'Default'): WidgetCategoryModel
+    {
+        $category = new WidgetCategoryModel;
+        $category->name = $name;
+        $category->save();
+
+        return $category;
+    }
+
+    private function makeWidget(array $overrides = []): WidgetModel
+    {
+        $widget = new WidgetModel;
+        $widget->fill(array_merge([
+            'name' => 'Widget '.uniqid('', true),
+            'sku' => 'SKU-'.uniqid('', true),
+            'quantity' => 10,
+            'price' => 9.99,
+            'is_active' => true,
+            'category_id' => null,
+        ], $overrides));
+        $widget->save();
+
+        return $widget;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  create / insert
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_create_inserts_a_row_and_hydrates_a_domain_object(): void
+    {
+        $widget = $this->repository->create([
+            'name' => 'Sprocket',
+            'sku' => 'SP-001',
+            'quantity' => 5,
+            'price' => 12.50,
+            'is_active' => true,
+        ]);
+
+        $this->assertInstanceOf(WidgetDomainObject::class, $widget);
+        $this->assertNotNull($widget->getId());
+        $this->assertSame('Sprocket', $widget->getName());
+        $this->assertSame(5, $widget->getQuantity());
+        $this->assertSame(12.50, $widget->getPrice());
+        $this->assertTrue($widget->getIsActive());
+
+        $this->assertDatabaseHas('br_test_widgets', ['sku' => 'SP-001']);
+    }
+
+    public function test_insert_bulk_inserts_rows_and_autofills_timestamps(): void
+    {
+        $result = $this->repository->insert([
+            ['name' => 'A', 'sku' => 'A-1', 'quantity' => 1, 'price' => 1, 'is_active' => true],
+            ['name' => 'B', 'sku' => 'B-1', 'quantity' => 2, 'price' => 2, 'is_active' => true],
+        ]);
+
+        $this->assertTrue($result);
+        $this->assertSame(2, WidgetModel::query()->count());
+        // both rows should have timestamps populated by the base repository
+        $this->assertSame(0, WidgetModel::query()->whereNull('created_at')->count());
+        $this->assertSame(0, WidgetModel::query()->whereNull('updated_at')->count());
+    }
+
+    public function test_insert_preserves_caller_supplied_timestamps(): void
+    {
+        $supplied = '2020-01-01 00:00:00';
+
+        $this->repository->insert([
+            [
+                'name' => 'A',
+                'sku' => 'A-1',
+                'quantity' => 1,
+                'price' => 1,
+                'is_active' => true,
+                'created_at' => $supplied,
+                'updated_at' => $supplied,
+            ],
+        ]);
+
+        $this->assertSame(1, WidgetModel::query()->where('created_at', $supplied)->count());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  findById / findFirst / findFirstByField / findFirstWhere
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_find_by_id_returns_hydrated_domain_object(): void
+    {
+        $widget = $this->makeWidget(['name' => 'Cog']);
+
+        $found = $this->repository->findById($widget->id);
+
+        $this->assertInstanceOf(WidgetDomainObject::class, $found);
+        $this->assertSame($widget->id, $found->getId());
+        $this->assertSame('Cog', $found->getName());
+    }
+
+    public function test_find_by_id_throws_when_missing(): void
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->repository->findById(999_999);
+    }
+
+    public function test_find_first_returns_domain_object_when_present(): void
+    {
+        $widget = $this->makeWidget(['name' => 'Hinge']);
+
+        $found = $this->repository->findFirst($widget->id);
+
+        $this->assertNotNull($found);
+        $this->assertSame('Hinge', $found->getName());
+    }
+
+    public function test_find_first_by_field_returns_match(): void
+    {
+        $this->makeWidget(['sku' => 'UNIQ-1']);
+
+        $found = $this->repository->findFirstByField('sku', 'UNIQ-1');
+
+        $this->assertNotNull($found);
+        $this->assertSame('UNIQ-1', $found->getSku());
+    }
+
+    public function test_find_first_by_field_returns_null_when_no_match(): void
+    {
+        $found = $this->repository->findFirstByField('sku', 'does-not-exist');
+
+        $this->assertNull($found);
+    }
+
+    public function test_find_first_where_returns_first_matching_row(): void
+    {
+        $this->makeWidget(['name' => 'A', 'is_active' => false]);
+        $this->makeWidget(['name' => 'B', 'is_active' => true]);
+
+        $found = $this->repository->findFirstWhere(['is_active' => true]);
+
+        $this->assertNotNull($found);
+        $this->assertSame('B', $found->getName());
+    }
+
+    public function test_find_first_where_returns_null_when_no_match(): void
+    {
+        $this->makeWidget(['is_active' => true]);
+
+        $this->assertNull($this->repository->findFirstWhere(['is_active' => false]));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  findWhere / findWhereIn / all / countWhere
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_find_where_returns_collection_of_domain_objects(): void
+    {
+        $this->makeWidget(['name' => 'A', 'is_active' => true]);
+        $this->makeWidget(['name' => 'B', 'is_active' => true]);
+        $this->makeWidget(['name' => 'C', 'is_active' => false]);
+
+        $results = $this->repository->findWhere(['is_active' => true]);
+
+        $this->assertInstanceOf(Collection::class, $results);
+        $this->assertCount(2, $results);
+        $this->assertContainsOnlyInstancesOf(WidgetDomainObject::class, $results);
+    }
+
+    public function test_find_where_orders_results_using_order_and_directions(): void
+    {
+        $this->makeWidget(['name' => 'B']);
+        $this->makeWidget(['name' => 'A']);
+        $this->makeWidget(['name' => 'C']);
+
+        $results = $this->repository->findWhere(
+            where: [],
+            orderAndDirections: [new OrderAndDirection('name', 'asc')],
+        );
+
+        $names = $results->map(fn (WidgetDomainObject $w) => $w->getName())->all();
+        $this->assertSame(['A', 'B', 'C'], $names);
+    }
+
+    public function test_find_where_in_filters_by_inclusion_with_additional_where(): void
+    {
+        $w1 = $this->makeWidget(['name' => 'X', 'is_active' => true]);
+        $w2 = $this->makeWidget(['name' => 'Y', 'is_active' => false]);
+        $this->makeWidget(['name' => 'Z', 'is_active' => true]);
+
+        $results = $this->repository->findWhereIn(
+            field: 'id',
+            values: [$w1->id, $w2->id],
+            additionalWhere: ['is_active' => true],
+        );
+
+        $this->assertCount(1, $results);
+        $this->assertSame('X', $results->first()->getName());
+    }
+
+    public function test_all_returns_every_row(): void
+    {
+        $this->makeWidget();
+        $this->makeWidget();
+        $this->makeWidget();
+
+        $this->assertCount(3, $this->repository->all());
+    }
+
+    public function test_count_where_counts_matching_rows(): void
+    {
+        $this->makeWidget(['is_active' => true]);
+        $this->makeWidget(['is_active' => true]);
+        $this->makeWidget(['is_active' => false]);
+
+        $this->assertSame(2, $this->repository->countWhere(['is_active' => true]));
+        $this->assertSame(3, $this->repository->countWhere([]));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  applyConditions DSL
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_apply_conditions_supports_in_operator(): void
+    {
+        $a = $this->makeWidget();
+        $b = $this->makeWidget();
+        $this->makeWidget();
+
+        $results = $this->repository->findWhere([
+            ['id', 'in', [$a->id, $b->id]],
+        ]);
+
+        $this->assertCount(2, $results);
+    }
+
+    public function test_apply_conditions_supports_not_in_operator(): void
+    {
+        $a = $this->makeWidget();
+        $this->makeWidget();
+        $this->makeWidget();
+
+        $results = $this->repository->findWhere([
+            ['id', 'not in', [$a->id]],
+        ]);
+
+        $this->assertCount(2, $results);
+    }
+
+    public function test_apply_conditions_supports_null_operator(): void
+    {
+        $this->makeWidget(['description' => null]);
+        $this->makeWidget(['description' => 'has text']);
+
+        $results = $this->repository->findWhere([
+            ['description', 'null', null],
+        ]);
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_apply_conditions_supports_not_null_operator(): void
+    {
+        $this->makeWidget(['description' => null]);
+        $this->makeWidget(['description' => 'has text']);
+
+        $results = $this->repository->findWhere([
+            ['description', 'not null', null],
+        ]);
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_apply_conditions_supports_comparison_operators(): void
+    {
+        $this->makeWidget(['quantity' => 5]);
+        $this->makeWidget(['quantity' => 10]);
+        $this->makeWidget(['quantity' => 15]);
+
+        $this->assertCount(2, $this->repository->findWhere([['quantity', '>=', 10]]));
+        $this->assertCount(1, $this->repository->findWhere([['quantity', '<', 10]]));
+        $this->assertCount(1, $this->repository->findWhere([['quantity', '=', 15]]));
+    }
+
+    public function test_apply_conditions_treats_simple_pairs_as_equality(): void
+    {
+        $this->makeWidget(['name' => 'foo']);
+        $this->makeWidget(['name' => 'bar']);
+
+        $results = $this->repository->findWhere(['name' => 'foo']);
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_apply_conditions_supports_callable_value(): void
+    {
+        $this->makeWidget(['name' => 'foo', 'is_active' => true]);
+        $this->makeWidget(['name' => 'bar', 'is_active' => true]);
+        $this->makeWidget(['name' => 'foo', 'is_active' => false]);
+
+        $results = $this->repository->findWhere([
+            'name' => 'foo',
+            // closure-as-value path through applyConditions
+            fn ($q) => $q->where('is_active', true),
+        ]);
+
+        $this->assertCount(1, $results);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  update / delete
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_update_from_array_persists_changes_and_returns_fresh_object(): void
+    {
+        $widget = $this->makeWidget(['name' => 'old', 'quantity' => 1]);
+
+        $updated = $this->repository->updateFromArray($widget->id, [
+            'name' => 'new',
+            'quantity' => 99,
+        ]);
+
+        $this->assertSame('new', $updated->getName());
+        $this->assertSame(99, $updated->getQuantity());
+        $this->assertDatabaseHas('br_test_widgets', ['id' => $widget->id, 'name' => 'new']);
+    }
+
+    public function test_update_where_returns_affected_count(): void
+    {
+        $this->makeWidget(['is_active' => true]);
+        $this->makeWidget(['is_active' => true]);
+        $this->makeWidget(['is_active' => false]);
+
+        $affected = $this->repository->updateWhere(
+            attributes: ['name' => 'renamed'],
+            where: ['is_active' => true],
+        );
+
+        $this->assertSame(2, $affected);
+        $this->assertSame(2, WidgetModel::query()->where('name', 'renamed')->count());
+    }
+
+    public function test_update_by_id_where_updates_when_predicate_matches(): void
+    {
+        $widget = $this->makeWidget(['is_active' => true, 'name' => 'old']);
+
+        $updated = $this->repository->updateByIdWhere(
+            id: $widget->id,
+            attributes: ['name' => 'new'],
+            where: ['is_active' => true],
+        );
+
+        $this->assertSame('new', $updated->getName());
+    }
+
+    public function test_update_by_id_where_throws_when_predicate_does_not_match(): void
+    {
+        $widget = $this->makeWidget(['is_active' => true]);
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->repository->updateByIdWhere(
+            id: $widget->id,
+            attributes: ['name' => 'new'],
+            where: ['is_active' => false],
+        );
+    }
+
+    public function test_delete_by_id_soft_deletes_the_row(): void
+    {
+        $widget = $this->makeWidget();
+
+        $this->assertTrue($this->repository->deleteById($widget->id));
+        $this->assertSoftDeleted('br_test_widgets', ['id' => $widget->id]);
+    }
+
+    public function test_delete_where_returns_affected_count(): void
+    {
+        $this->makeWidget(['is_active' => true]);
+        $this->makeWidget(['is_active' => true]);
+        $this->makeWidget(['is_active' => false]);
+
+        $deleted = $this->repository->deleteWhere(['is_active' => true]);
+
+        $this->assertSame(2, $deleted);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  increment / decrement
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_increment_bumps_an_integer_column(): void
+    {
+        $widget = $this->makeWidget(['quantity' => 10]);
+
+        $this->repository->increment($widget->id, 'quantity', 3);
+
+        $this->assertSame(13, (int) WidgetModel::query()->find($widget->id)->quantity);
+    }
+
+    public function test_increment_supports_float_amount(): void
+    {
+        $widget = $this->makeWidget(['price' => 10.00]);
+
+        $this->repository->increment($widget->id, 'price', 2.50);
+
+        $this->assertSame(12.50, (float) WidgetModel::query()->find($widget->id)->price);
+    }
+
+    public function test_decrement_lowers_an_integer_column(): void
+    {
+        $widget = $this->makeWidget(['quantity' => 10]);
+
+        $this->repository->decrement($widget->id, 'quantity', 4);
+
+        $this->assertSame(6, (int) WidgetModel::query()->find($widget->id)->quantity);
+    }
+
+    public function test_increment_where_bumps_matching_rows(): void
+    {
+        $a = $this->makeWidget(['quantity' => 1, 'is_active' => true]);
+        $b = $this->makeWidget(['quantity' => 1, 'is_active' => true]);
+        $c = $this->makeWidget(['quantity' => 1, 'is_active' => false]);
+
+        $this->repository->incrementWhere(['is_active' => true], 'quantity', 5);
+
+        $this->assertSame(6, (int) WidgetModel::query()->find($a->id)->quantity);
+        $this->assertSame(6, (int) WidgetModel::query()->find($b->id)->quantity);
+        $this->assertSame(1, (int) WidgetModel::query()->find($c->id)->quantity);
+    }
+
+    public function test_increment_each_updates_multiple_columns(): void
+    {
+        $widget = $this->makeWidget(['quantity' => 1, 'price' => 1.00]);
+
+        $this->repository->incrementEach(
+            columns: ['quantity' => 2, 'price' => 3.00],
+            where: ['id' => $widget->id],
+        );
+
+        $fresh = WidgetModel::query()->find($widget->id);
+        $this->assertSame(3, (int) $fresh->quantity);
+        $this->assertSame(4.00, (float) $fresh->price);
+    }
+
+    public function test_decrement_each_updates_multiple_columns(): void
+    {
+        $widget = $this->makeWidget(['quantity' => 10, 'price' => 10.00]);
+
+        $this->repository->decrementEach(
+            where: ['id' => $widget->id],
+            columns: ['quantity' => 2, 'price' => 1.00],
+        );
+
+        $fresh = WidgetModel::query()->find($widget->id);
+        $this->assertSame(8, (int) $fresh->quantity);
+        $this->assertSame(9.00, (float) $fresh->price);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  Pagination
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_paginate_returns_a_length_aware_paginator(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->makeWidget();
+        }
+
+        $page = $this->repository->paginate(limit: 2);
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $page);
+        $this->assertSame(5, $page->total());
+        $this->assertCount(2, $page->items());
+        $this->assertContainsOnlyInstancesOf(WidgetDomainObject::class, $page->items());
+    }
+
+    public function test_paginate_where_filters_then_paginates(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            $this->makeWidget(['is_active' => true]);
+        }
+        $this->makeWidget(['is_active' => false]);
+
+        $page = $this->repository->paginateWhere(['is_active' => true], limit: 2);
+
+        $this->assertSame(3, $page->total());
+        $this->assertCount(2, $page->items());
+    }
+
+    public function test_simple_paginate_where_returns_a_simple_paginator(): void
+    {
+        for ($i = 0; $i < 4; $i++) {
+            $this->makeWidget(['is_active' => true]);
+        }
+
+        $page = $this->repository->simplePaginateWhere(['is_active' => true], limit: 2);
+
+        $this->assertInstanceOf(Paginator::class, $page);
+        $this->assertCount(2, $page->items());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  Eager loading
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_load_relation_hydrates_a_belongs_to_relation(): void
+    {
+        $category = $this->makeCategory('Tools');
+        $widget = $this->makeWidget(['category_id' => $category->id]);
+
+        $found = $this->repository
+            ->loadRelation(new Relationship(WidgetCategoryDomainObject::class, name: 'category'))
+            ->findById($widget->id);
+
+        $this->assertNotNull($found->getCategory());
+        $this->assertInstanceOf(WidgetCategoryDomainObject::class, $found->getCategory());
+        $this->assertSame('Tools', $found->getCategory()->getName());
+    }
+
+    public function test_load_relation_hydrates_a_has_many_relation_as_a_collection(): void
+    {
+        $category = $this->makeCategory('Bolts');
+        $this->makeWidget(['category_id' => $category->id, 'name' => 'M3']);
+        $this->makeWidget(['category_id' => $category->id, 'name' => 'M4']);
+
+        $found = $this->categoryRepository
+            ->loadRelation(new Relationship(WidgetDomainObject::class, name: 'widgets'))
+            ->findById($category->id);
+
+        $this->assertInstanceOf(Collection::class, $found->getWidgets());
+        $this->assertCount(2, $found->getWidgets());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  Soft deletes / includeDeleted
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_include_deleted_returns_soft_deleted_rows(): void
+    {
+        $widget = $this->makeWidget();
+        $this->repository->deleteById($widget->id);
+
+        $this->assertNull($this->repository->findFirstWhere(['id' => $widget->id]));
+
+        $found = $this->repository->includeDeleted()->findFirstWhere(['id' => $widget->id]);
+        $this->assertNotNull($found);
+        $this->assertSame($widget->id, $found->getId());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  State reset (the actual point of the refactor)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_consecutive_finds_do_not_leak_where_clauses(): void
+    {
+        $a = $this->makeWidget(['is_active' => true]);
+        $b = $this->makeWidget(['is_active' => false]);
+
+        // First call applies a where(is_active, true)
+        $first = $this->repository->findWhere(['is_active' => true]);
+        $this->assertCount(1, $first);
+
+        // Second call must NOT inherit the previous where clause
+        $second = $this->repository->findWhere([]);
+        $this->assertCount(2, $second, 'Second findWhere([]) inherited state from the previous query');
+    }
+
+    public function test_eager_loads_are_reset_between_queries(): void
+    {
+        $category = $this->makeCategory('Cat');
+        $widgetA = $this->makeWidget(['category_id' => $category->id]);
+        $widgetB = $this->makeWidget(['category_id' => $category->id]);
+
+        $first = $this->repository
+            ->loadRelation(new Relationship(WidgetCategoryDomainObject::class, name: 'category'))
+            ->findById($widgetA->id);
+        $this->assertNotNull($first->getCategory());
+
+        // After the call, eagerLoads MUST be cleared. Previously this was a bug —
+        // resetModel() reset the builder but left $eagerLoads populated, so the
+        // array would grow unboundedly across calls on the same instance.
+        $this->assertSame([], $this->repository->exposeEagerLoads());
+
+        // A subsequent call without loadRelation() must produce an unhydrated relation.
+        $second = $this->repository->findById($widgetB->id);
+        $this->assertNull($second->getCategory());
+    }
+
+    public function test_state_is_reset_even_when_the_query_throws(): void
+    {
+        $this->makeWidget(['is_active' => true]);
+
+        try {
+            // findById on a missing id throws ModelNotFoundException — but only
+            // AFTER the loadRelation call has registered an eager load and added
+            // a where clause.
+            $this->repository
+                ->loadRelation(new Relationship(WidgetCategoryDomainObject::class, name: 'category'))
+                ->findById(999_999);
+            $this->fail('Expected ModelNotFoundException');
+        } catch (ModelNotFoundException) {
+            // expected
+        }
+
+        // The next call on the same repository instance must start clean.
+        $this->assertSame([], $this->repository->exposeEagerLoads());
+        $this->assertFalse($this->repository->exposeBuilderHasWheres());
+    }
+
+    public function test_set_max_per_page_caps_pagination_size(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->makeWidget();
+        }
+
+        $page = $this->repository->setMaxPerPage(3)->paginate(limit: 100);
+
+        $this->assertCount(3, $page->items());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  Hydration edge cases
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_hydration_calls_setters_via_studly_case(): void
+    {
+        // category_id is a snake_case column → setCategoryId on the domain object
+        $category = $this->makeCategory();
+        $widget = $this->makeWidget(['category_id' => $category->id]);
+
+        $found = $this->repository->findById($widget->id);
+
+        $this->assertSame($category->id, $found->getCategoryId());
+    }
+
+    public function test_hydration_silently_skips_columns_with_no_setter(): void
+    {
+        // No setter exists on WidgetDomainObject for an unknown column.
+        // Add a column on the fly via raw SQL so the model picks it up.
+        Schema::table('br_test_widgets', function (Blueprint $table) {
+            $table->string('mystery_field')->nullable();
+        });
+
+        $widget = $this->makeWidget();
+        WidgetModel::query()->where('id', $widget->id)->update(['mystery_field' => 'something']);
+
+        // Should not throw — the silent-skip behaviour is documented.
+        $found = $this->repository->findById($widget->id);
+        $this->assertNotNull($found);
+    }
+}

--- a/backend/tests/Unit/Repository/Fixtures/WidgetCategoryDomainObject.php
+++ b/backend/tests/Unit/Repository/Fixtures/WidgetCategoryDomainObject.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Repository\Fixtures;
+
+use HiEvents\DomainObjects\AbstractDomainObject;
+use Illuminate\Support\Collection;
+
+class WidgetCategoryDomainObject extends AbstractDomainObject
+{
+    public const SINGULAR_NAME = 'widget_category';
+
+    public const PLURAL_NAME = 'widget_categories';
+
+    protected ?int $id = null;
+
+    protected ?string $name = null;
+
+    protected ?Collection $widgets = null;
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setWidgets(?Collection $widgets): self
+    {
+        $this->widgets = $widgets;
+
+        return $this;
+    }
+
+    public function getWidgets(): ?Collection
+    {
+        return $this->widgets;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+        ];
+    }
+}

--- a/backend/tests/Unit/Repository/Fixtures/WidgetCategoryModel.php
+++ b/backend/tests/Unit/Repository/Fixtures/WidgetCategoryModel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Repository\Fixtures;
+
+use HiEvents\Models\BaseModel;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class WidgetCategoryModel extends BaseModel
+{
+    protected $table = 'br_test_widget_categories';
+
+    protected function getFillableFields(): array
+    {
+        return ['name'];
+    }
+
+    public function widgets(): HasMany
+    {
+        return $this->hasMany(WidgetModel::class, 'category_id');
+    }
+}

--- a/backend/tests/Unit/Repository/Fixtures/WidgetCategoryRepository.php
+++ b/backend/tests/Unit/Repository/Fixtures/WidgetCategoryRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Repository\Fixtures;
+
+use HiEvents\Repository\Eloquent\BaseRepository;
+
+/**
+ * @extends BaseRepository<WidgetCategoryDomainObject>
+ */
+class WidgetCategoryRepository extends BaseRepository
+{
+    protected function getModel(): string
+    {
+        return WidgetCategoryModel::class;
+    }
+
+    public function getDomainObject(): string
+    {
+        return WidgetCategoryDomainObject::class;
+    }
+}

--- a/backend/tests/Unit/Repository/Fixtures/WidgetDomainObject.php
+++ b/backend/tests/Unit/Repository/Fixtures/WidgetDomainObject.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Repository\Fixtures;
+
+use HiEvents\DomainObjects\AbstractDomainObject;
+
+class WidgetDomainObject extends AbstractDomainObject
+{
+    public const SINGULAR_NAME = 'widget';
+
+    public const PLURAL_NAME = 'widgets';
+
+    protected ?int $id = null;
+
+    protected ?int $category_id = null;
+
+    protected ?string $name = null;
+
+    protected ?string $sku = null;
+
+    protected ?int $quantity = null;
+
+    protected ?float $price = null;
+
+    protected ?bool $is_active = null;
+
+    protected ?string $description = null;
+
+    protected ?string $created_at = null;
+
+    protected ?string $updated_at = null;
+
+    protected ?string $deleted_at = null;
+
+    protected ?WidgetCategoryDomainObject $category = null;
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setCategoryId(?int $category_id): self
+    {
+        $this->category_id = $category_id;
+
+        return $this;
+    }
+
+    public function getCategoryId(): ?int
+    {
+        return $this->category_id;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setSku(?string $sku): self
+    {
+        $this->sku = $sku;
+
+        return $this;
+    }
+
+    public function getSku(): ?string
+    {
+        return $this->sku;
+    }
+
+    public function setQuantity(?int $quantity): self
+    {
+        $this->quantity = $quantity;
+
+        return $this;
+    }
+
+    public function getQuantity(): ?int
+    {
+        return $this->quantity;
+    }
+
+    public function setPrice(float|int|null $price): self
+    {
+        $this->price = $price === null ? null : (float) $price;
+
+        return $this;
+    }
+
+    public function getPrice(): ?float
+    {
+        return $this->price;
+    }
+
+    public function setIsActive(?bool $is_active): self
+    {
+        $this->is_active = $is_active;
+
+        return $this;
+    }
+
+    public function getIsActive(): ?bool
+    {
+        return $this->is_active;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setCreatedAt(?string $created_at): self
+    {
+        $this->created_at = $created_at;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->created_at;
+    }
+
+    public function setUpdatedAt(?string $updated_at): self
+    {
+        $this->updated_at = $updated_at;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updated_at;
+    }
+
+    public function setDeletedAt(?string $deleted_at): self
+    {
+        $this->deleted_at = $deleted_at;
+
+        return $this;
+    }
+
+    public function getDeletedAt(): ?string
+    {
+        return $this->deleted_at;
+    }
+
+    public function setCategory(?WidgetCategoryDomainObject $category): self
+    {
+        $this->category = $category;
+
+        return $this;
+    }
+
+    public function getCategory(): ?WidgetCategoryDomainObject
+    {
+        return $this->category;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'category_id' => $this->category_id,
+            'name' => $this->name,
+            'sku' => $this->sku,
+            'quantity' => $this->quantity,
+            'price' => $this->price,
+            'is_active' => $this->is_active,
+            'description' => $this->description,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+            'deleted_at' => $this->deleted_at,
+        ];
+    }
+}

--- a/backend/tests/Unit/Repository/Fixtures/WidgetModel.php
+++ b/backend/tests/Unit/Repository/Fixtures/WidgetModel.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Repository\Fixtures;
+
+use HiEvents\Models\BaseModel;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class WidgetModel extends BaseModel
+{
+    use SoftDeletes;
+
+    protected $table = 'br_test_widgets';
+
+    protected function getFillableFields(): array
+    {
+        return [
+            'category_id',
+            'name',
+            'sku',
+            'quantity',
+            'price',
+            'is_active',
+            'description',
+        ];
+    }
+
+    protected function getCastMap(): array
+    {
+        return [
+            'is_active' => 'boolean',
+            'quantity' => 'integer',
+            'price' => 'float',
+        ];
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(WidgetCategoryModel::class, 'category_id');
+    }
+}

--- a/backend/tests/Unit/Repository/Fixtures/WidgetRepository.php
+++ b/backend/tests/Unit/Repository/Fixtures/WidgetRepository.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Repository\Fixtures;
+
+use HiEvents\Repository\Eloquent\BaseRepository;
+
+/**
+ * Concrete BaseRepository subclass used by BaseRepositoryTest.
+ *
+ * Exists only in tests so we can exercise BaseRepository against an isolated
+ * fixture table without coupling tests to any specific production entity.
+ *
+ * @extends BaseRepository<WidgetDomainObject>
+ */
+class WidgetRepository extends BaseRepository
+{
+    protected function getModel(): string
+    {
+        return WidgetModel::class;
+    }
+
+    public function getDomainObject(): string
+    {
+        return WidgetDomainObject::class;
+    }
+
+    /**
+     * Test hooks: expose protected state so we can assert reset behaviour
+     * without resorting to reflection.
+     */
+    public function exposeEagerLoads(): array
+    {
+        return $this->eagerLoads;
+    }
+
+    public function exposeBuilderHasWheres(): bool
+    {
+        $base = $this->model->getQuery();
+
+        return ! empty($base->wheres);
+    }
+}

--- a/docker/development/docker-compose.dev.yml
+++ b/docker/development/docker-compose.dev.yml
@@ -109,8 +109,11 @@ services:
             POSTGRES_DB: '${DB_DATABASE}'
             POSTGRES_USER: '${DB_USERNAME}'
             POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
+            TEST_DB_NAME: '${TEST_DB_NAME:-hievents_test}'
         volumes:
             - 'app-pgsql:/var/lib/postgresql/data'
+            # Init scripts run once on a fresh data volume — creates hievents_test.
+            - './pgsql-init:/docker-entrypoint-initdb.d:ro'
         networks:
             - app
         healthcheck:

--- a/docker/development/pgsql-init/01-create-test-db.sh
+++ b/docker/development/pgsql-init/01-create-test-db.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Postgres entrypoint init script — runs once on a fresh data volume.
+# Creates the hievents_test database used by the test suite (the BaseRepositoryTest
+# guard refuses to run against any database whose name does not end in _test).
+#
+# Idempotent: existing test DBs are left alone.
+
+set -euo pipefail
+
+TEST_DB="${TEST_DB_NAME:-hievents_test}"
+
+psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" <<-EOSQL
+    SELECT 'CREATE DATABASE ${TEST_DB} OWNER ${POSTGRES_USER}'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${TEST_DB}')\gexec
+EOSQL
+
+echo "Test database '${TEST_DB}' is ready."


### PR DESCRIPTION
## Summary

Three layers, one PR — they build on each other:

1. **`refactor(repository)`** — Hardens `BaseRepository` state reset and fixes a real bug in `incrementEach`/`decrementEach` where the affected-row count was being silently swallowed by `Eloquent\Builder::__call`. Wraps every public query method in a `try`/`finally` so per-call state (`$this->model`, `$this->eagerLoads`) is reset even when the underlying query throws — previously, an exception left state leaking into the next call on the same singleton-bound repo.
2. **`test(repository)`** — Adds `BaseRepositoryTest` with **46 cases / 88 assertions** covering CRUD, the full `applyConditions` DSL, increment/decrement (including the regression test for the `Builder` return-value bug), pagination, eager loading, soft deletes, and the new state-reset guarantees. Backed by isolated `br_test_widgets` / `br_test_widget_categories` fixture tables created/dropped per test, so it's decoupled from production tables.
3. **`test(infra)`** — Codebase-wide test database support so any current or future test that needs a real DB can use one safely:
   - **`backend/.env.testing`** — Laravel auto-loads when `APP_ENV=testing`. Static test-only `APP_KEY`/`JWT_SECRET`, hermetic drivers, DB pointed at `hievents_test`. Safe to commit.
   - **`backend/phpunit.xml`** — `<env force="true">` for `DB_DATABASE` so the test DB name cannot be silently overridden by a developer's `.env`.
   - **`backend/tests/TestCase.php`** — `final guardAgainstNonTestDatabase()` runs in `setUp()` on **every** test that boots Laravel. Refuses to start if the default connection's database name does not end in `_test`. Reads config only — no connection opened — so mocked tests pay only a constant-time cost and need no test DB to boot.
   - **`.github/workflows/unit-tests.yml`** — `postgres:15` service container, `pdo_pgsql` extensions, job-level env overrides for the runner host, `pg_isready` wait loop. (Workflow previously had no DB at all.)
   - **`docker/development/pgsql-init/01-create-test-db.sh`** — idempotent init script mounted into the local pgsql container's `/docker-entrypoint-initdb.d/` so new clones get a working test DB out of the box.
   - **`CLAUDE.md`** — testing section now documents the `_test` naming requirement, the global guard, and the manual DB creation command for legacy pgsql volumes.

## Why the `_test` guard

The new `BaseRepositoryTest` creates and drops real tables on the active connection. A misconfigured environment could in principle hit a dev/staging/prod DB. The guard makes that impossible: any test that boots Laravel refuses to start unless the configured DB name ends in `_test`. It's `final` so no subclass can disable it.

## Local migration for existing devs

If your local pgsql data volume predates this PR, the init script won't re-run on it. Create the test DB once:

\`\`\`
docker compose -f docker-compose.dev.yml exec pgsql \
  psql -U username -d backend -c 'CREATE DATABASE hievents_test OWNER username;'
\`\`\`

New clones get this automatically via the init script.

## Test plan

- [x] `php artisan test --filter=BaseRepositoryTest` → **46 passed** (88 assertions)
- [x] `php artisan test --testsuite=Unit` → **399 passed** (1 deprecated, 1 skipped — both pre-existing on `main`)
- [x] `php artisan test tests/Feature/Auth/LoginTest.php` → **3 passed** — proves the DB infra also supports `RefreshDatabase` + factories for any future Feature test
- [x] Guard fires correctly when forced against a non-`_test` DB (`DB_DATABASE=backend php artisan test`) — clear error, no DDL runs
- [x] Init script verified on a fresh ephemeral postgres container (custom `TEST_DB_NAME` works, idempotent against existing test DBs)
- [x] Workflow YAML parses correctly
- [x] Full Laravel boot under simulated CI conditions (no container `APP_KEY`, only `.env.testing`) → 32-byte AES key, all hermetic drivers, JWT loaded