### PR TITLE
fix: Sized image dimensions are lost upon page reload (image shows up again as 100% full width) 🤖 

### DIFF
--- a/frontend/src/components/common/Editor/Extensions/ImageResizeExtension/index.tsx
+++ b/frontend/src/components/common/Editor/Extensions/ImageResizeExtension/index.tsx
@@ -5,7 +5,7 @@ import { NodeViewProps } from '@tiptap/react';
  * Adapted from https://github.com/bae-sh/tiptap-extension-resize-image/blob/main/lib/imageResize.ts
  */
 export const ImageResize = Image.extend({
-    name: 'imageResize',
+    name: 'image',
     addAttributes() {
         return {
             ...this.parent?.(),

--- a/frontend/src/components/common/Editor/Extensions/ImageResizeExtension/index.tsx
+++ b/frontend/src/components/common/Editor/Extensions/ImageResizeExtension/index.tsx
@@ -17,6 +17,9 @@ export const ImageResize = Image.extend({
                         ? `width: ${width}px; height: auto; cursor: pointer;`
                         : `${element.style.cssText}`;
                 },
+                renderHTML: (attributes: Record<string, string>) => {
+                    return { style: attributes.style };
+                },
             },
         };
     },

--- a/frontend/src/components/common/Editor/index.tsx
+++ b/frontend/src/components/common/Editor/index.tsx
@@ -3,7 +3,6 @@ import {useEditor} from "@tiptap/react";
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import TextAlign from '@tiptap/extension-text-align';
-import Image from '@tiptap/extension-image';
 import TextStyle from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
 import React, {useEffect, useState} from "react";
@@ -63,7 +62,6 @@ export const Editor = ({
             Underline,
             Link,
             TextAlign.configure({types: ['heading', 'paragraph']}),
-            Image,
             ImageResize,
             TextStyle,
             Color,


### PR DESCRIPTION
Body:
  ## What changes I've made

  - Renamed `ImageResize` extension from `'imageResize'` to `'image'` so it fully replaces the base TipTap Image extension
  - Removed the redundant base `Image` extension registration from the Editor

  ## Why I've made these changes

  Resized image dimensions are lost on save/reload. Both the base `Image` (name: `'image'`) and `ImageResize` (name: `'imageResize'`) extensions were registered simultaneously. When TipTap parses saved HTML, it matches `<img>` tags to the `'image'` node type — the base extension, which doesn't persist the `style` attribute. By renaming `ImageResize` to `'image'` and removing the base, the resize-aware extension fully owns `<img>` parsing and preserves dimensions.

  ## How I've tested these changes

  - Inserted an image in the editor, resized it via drag handles
  - Saved, navigated away (including to different page), returned — image retained its resized dimensions
  - Verified resize handles still appear and function correctly
  - Confirmed new images default to 100% width as expected

  ## Checklist

  - [x] I have read the [contributing guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md).
  - [x] My code follows the coding standards of the project.
  - [x] I have tested my changes, and they work as expected.
  - [x] I understand that this PR will be closed if I do not follow the [contributor guidelines] https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md) and if this PR template is left unedited.