### PR TITLE
fix(LanguageSwitcher): add default case to prevent SSR crash on unhandled locale

### DIFF
--- a/frontend/src/components/common/LanguageSwitcher/index.tsx
+++ b/frontend/src/components/common/LanguageSwitcher/index.tsx
@@ -40,6 +40,13 @@ export const LanguageSwitcher = () => {
                 return t`Polish`;
             case "se":
                 return t`Swedish`;
+            default:
+                // Defensive fallback: if a new locale is added to SupportedLocales
+                // but not handled here, return the locale code itself rather than
+                // undefined. An undefined label propagates into Mantine's Combobox
+                // `defaultOptionsFilter`, which calls `.toLowerCase()` on it and
+                // throws during SSR, 500-ing every auth page.
+                return locale;
         }
     };
 


### PR DESCRIPTION
## Problem

`getLocaleName`'s switch over `SupportedLocales` has no default branch. If any locale is added to the `SupportedLocales` type but the switch is not updated, the function returns `undefined` implicitly. That undefined label reaches Mantine `Combobox`'s `defaultOptionsFilter`, which calls `.toLowerCase()` on it during SSR and throws, returning **500 for every /auth/* route** (login, register, forgot-password) until the user's locale cookie is cleared.

## Root cause

```ts
const getLocaleName = (locale: SupportedLocales): string => {
    switch (locale) {
        case "hu": return t`Hungarian`;
        // ...
        case "se": return t`Swedish`;
    }
    // ← no default, TypeScript doesn't complain because all listed cases return
};
```

TypeScript's exhaustiveness check doesn't help here because the function signature says it returns `string` — adding a new member to the union type without adjusting the switch silently becomes "returns `undefined` at runtime."

## Fix

Add a `default` branch returning the locale code itself. A locale code shown instead of a translated name is a minor UX blemish; a 500 on every auth route is a production outage.

Alternative considered: `never`-based exhaustiveness check (would force compilation errors). Not chosen because that would break backward compatibility when downstream fork adds a locale without touching this file.

## Reproduction

1. Add `"ko"` to `SupportedLocales` + `availableLocales` in `frontend/src/locales.ts`
2. Register a user, then `PUT /api/users/me { locale: "ko" }`
3. Reload `/auth/login` — 500

Stack:
```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at defaultOptionsFilter (@mantine/core/esm/components/Combobox/OptionsDropdown/default-options-filter.mjs:27)
    at OptionsDropdown (@mantine/core/esm/components/Combobox/OptionsDropdown/OptionsDropdown.mjs:88)
    at ... react-dom-server-legacy.node.production.min.js
```

## Test plan

- [x] Manual: locale=ko cookie no longer 500s /auth/login/register/forgot-password
- [ ] Unit: `getLocaleName("ko" as SupportedLocales)` returns `"ko"` instead of undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)