### PR TITLE
i18n: wrap hardcoded 'at' in order summary email in __()

### DIFF
--- a/backend/resources/views/emails/orders/summary.blade.php
+++ b/backend/resources/views/emails/orders/summary.blade.php
@@ -37,7 +37,7 @@
 # {{ __('Event Details') }}
 **{{ __('Event Name:') }}** {{ $event->getTitle() }}
     <br>
-**{{ __('Date & Time:') }}** {{ (new Carbon(DateHelper::convertFromUTC($event->getStartDate(), $event->getTimezone())))->format('F j, Y') }} at {{ (new Carbon(DateHelper::convertFromUTC($event->getStartDate(), $event->getTimezone())))->format('g:i A') }}
+**{{ __('Date & Time:') }}** {{ __(':date at :time', ['date' => (new Carbon(DateHelper::convertFromUTC($event->getStartDate(), $event->getTimezone())))->format('F j, Y'), 'time' => (new Carbon(DateHelper::convertFromUTC($event->getStartDate(), $event->getTimezone())))->format('g:i A')]) }}
 
 </p>
 


### PR DESCRIPTION
## Problem

`backend/resources/views/emails/orders/summary.blade.php:40` has one hardcoded English word between the date and time:

```blade
**{{ __('Date & Time:') }}** {{ …->format('F j, Y') }} at {{ …->format('g:i A') }}
```

All surrounding strings already use `__()`, so in non-English locales the email renders like:

- Korean: "2026년 5월 1일 **at** 오후 2:00"
- Japanese: "2026年5月1日 **at** 午後2:00"
- Chinese: "2026年5月1日 **at** 下午2:00"

## Fix

Wrap the whole phrase with `:date` / `:time` placeholders:

```blade
{{ __(':date at :time', ['date' => …, 'time' => …]) }}
```

Translators can now reorder or replace the separator. Korean might prefer `:date :time` (no connector) or `:date · :time`.

No logic change — Carbon/DateHelper formatting untouched.

## Test plan

- [x] English: identical output
- [ ] Translator sees new msgid `:date at :time` on next `lingui extract` equivalent run (note: Laravel translations are stored in `lang/{locale}.json` — pre-existing keys in translation files stay; this adds a new key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)