### PR TITLE
fix: Custom email template for Attendees incorrectly routes back to Order (fix by preserving correct cta.url_token on update) 🤖 

### DIFF
--- a/backend/app/Console/Commands/RepairEmailTemplateCtaCommand.php
+++ b/backend/app/Console/Commands/RepairEmailTemplateCtaCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace HiEvents\Console\Commands;
+
+use HiEvents\DomainObjects\Enums\EmailTemplateType;
+use HiEvents\Models\EmailTemplate;
+use HiEvents\Services\Domain\Email\EmailTemplateService;
+use Illuminate\Console\Command;
+
+class RepairEmailTemplateCtaCommand extends Command
+{
+    protected $signature = 'email-templates:repair-cta-url-token
+                            {--dry-run : Show what would change without writing}';
+
+    protected $description = 'Reset cta.url_token on email_templates rows to the default for each template_type. Repairs damage from a prior bug where attendee_ticket templates were saved with order.url.';
+
+    public function __construct(private readonly EmailTemplateService $emailTemplateService)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        $defaults = [];
+        foreach (EmailTemplateType::cases() as $type) {
+            $defaults[$type->value] = $this->emailTemplateService->getDefaultTemplate($type)['cta']['url_token'] ?? null;
+        }
+
+        $rows = EmailTemplate::query()->get();
+        $changed = 0;
+        $skipped = 0;
+
+        foreach ($rows as $row) {
+            $type = $row->template_type;
+            $expected = $defaults[$type] ?? null;
+
+            if ($expected === null) {
+                $skipped++;
+
+                continue;
+            }
+
+            $cta = is_array($row->cta) ? $row->cta : (json_decode((string) $row->cta, true) ?: null);
+
+            if ($cta === null) {
+                $skipped++;
+
+                continue;
+            }
+
+            $current = $cta['url_token'] ?? null;
+
+            if ($current === $expected) {
+                $skipped++;
+
+                continue;
+            }
+
+            $this->line(sprintf(
+                'id=%d type=%s url_token: %s -> %s',
+                $row->id,
+                $type,
+                var_export($current, true),
+                var_export($expected, true),
+            ));
+
+            if (! $dryRun) {
+                $cta['url_token'] = $expected;
+                $row->cta = $cta;
+                $row->save();
+            }
+
+            $changed++;
+        }
+
+        $this->info(sprintf('%s%d changed, %d unchanged.', $dryRun ? '[dry-run] ' : '', $changed, $skipped));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Http/Actions/EmailTemplates/UpdateEventEmailTemplateAction.php
+++ b/backend/app/Http/Actions/EmailTemplates/UpdateEventEmailTemplateAction.php
@@ -21,9 +21,7 @@ class UpdateEventEmailTemplateAction extends BaseEmailTemplateAction
 {
     public function __construct(
         private readonly UpdateEmailTemplateHandler $handler
-    )
-    {
-    }
+    ) {}
 
     /**
      * @throws ValidationException
@@ -43,9 +41,8 @@ class UpdateEventEmailTemplateAction extends BaseEmailTemplateAction
         try {
             $cta = [
                 'label' => $validated['ctaLabel'],
-                'url_token' => 'order.url', // This will be determined by template type during update
             ];
-            
+
             $template = $this->handler->handle(
                 new UpsertEmailTemplateDTO(
                     account_id: $this->getAuthenticatedAccountId(),

--- a/backend/app/Http/Actions/EmailTemplates/UpdateOrganizerEmailTemplateAction.php
+++ b/backend/app/Http/Actions/EmailTemplates/UpdateOrganizerEmailTemplateAction.php
@@ -10,8 +10,8 @@ use HiEvents\Exceptions\EmailTemplateValidationException;
 use HiEvents\Exceptions\InvalidEmailTemplateException;
 use HiEvents\Http\Resources\EmailTemplateResource;
 use HiEvents\Http\ResponseCodes;
-use HiEvents\Services\Application\Handlers\EmailTemplate\UpdateEmailTemplateHandler;
 use HiEvents\Services\Application\Handlers\EmailTemplate\DTO\UpsertEmailTemplateDTO;
+use HiEvents\Services\Application\Handlers\EmailTemplate\UpdateEmailTemplateHandler;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -21,8 +21,7 @@ class UpdateOrganizerEmailTemplateAction extends BaseEmailTemplateAction
 {
     public function __construct(
         private readonly UpdateEmailTemplateHandler $handler
-    ) {
-    }
+    ) {}
 
     /**
      * @throws ValidationException
@@ -42,9 +41,8 @@ class UpdateOrganizerEmailTemplateAction extends BaseEmailTemplateAction
         try {
             $cta = [
                 'label' => $validated['ctaLabel'],
-                'url_token' => 'order.url', // This will be determined by template type during update
             ];
-            
+
             $template = $this->handler->handle(
                 new UpsertEmailTemplateDTO(
                     account_id: $this->getAuthenticatedAccountId(),

--- a/backend/app/Services/Application/Handlers/EmailTemplate/UpdateEmailTemplateHandler.php
+++ b/backend/app/Services/Application/Handlers/EmailTemplate/UpdateEmailTemplateHandler.php
@@ -3,6 +3,7 @@
 namespace HiEvents\Services\Application\Handlers\EmailTemplate;
 
 use HiEvents\DomainObjects\EmailTemplateDomainObject;
+use HiEvents\DomainObjects\Enums\EmailTemplateType;
 use HiEvents\Exceptions\EmailTemplateNotFoundException;
 use HiEvents\Exceptions\EmailTemplateValidationException;
 use HiEvents\Exceptions\InvalidEmailTemplateException;
@@ -17,8 +18,7 @@ class UpdateEmailTemplateHandler
         private readonly EmailTemplateRepositoryInterface $emailTemplateRepository,
         private readonly EmailTemplateService $emailTemplateService,
         private readonly HtmlPurifierService $purifier,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws EmailTemplateValidationException
@@ -27,12 +27,12 @@ class UpdateEmailTemplateHandler
      */
     public function handle(UpsertEmailTemplateDTO $dto): EmailTemplateDomainObject
     {
-        if (!$dto->id) {
+        if (! $dto->id) {
             throw new InvalidEmailTemplateException('Template ID is required for update');
         }
 
         $validation = $this->emailTemplateService->validateTemplate($dto->subject, $dto->body);
-        if (!$validation['valid']) {
+        if (! $validation['valid']) {
             $exception = new EmailTemplateValidationException('Template validation failed');
             $exception->validationErrors = $validation['errors'];
             throw $exception;
@@ -43,16 +43,32 @@ class UpdateEmailTemplateHandler
             'account_id' => $dto->account_id,
         ]);
 
-        if (!$template) {
+        if (! $template) {
             throw new EmailTemplateNotFoundException('Email template not found');
         }
 
         return $this->emailTemplateRepository->updateFromArray($template->getId(), [
             'subject' => $dto->subject,
             'body' => $this->purifier->purify($dto->body),
-            'cta' => $dto->cta,
+            'cta' => $this->resolveCta($dto->cta, $template->getTemplateType()),
             'engine' => $dto->engine->value,
             'is_active' => $dto->is_active,
         ]);
+    }
+
+    private function resolveCta(?array $cta, string $templateType): ?array
+    {
+        if ($cta === null) {
+            return null;
+        }
+
+        $defaultCta = $this->emailTemplateService->getDefaultTemplate(
+            EmailTemplateType::from($templateType)
+        )['cta'] ?? null;
+
+        return [
+            'label' => $cta['label'] ?? $defaultCta['label'] ?? '',
+            'url_token' => $defaultCta['url_token'] ?? ($cta['url_token'] ?? null),
+        ];
     }
 }

--- a/backend/tests/Unit/Services/Application/Handlers/EmailTemplate/UpdateEmailTemplateHandlerTest.php
+++ b/backend/tests/Unit/Services/Application/Handlers/EmailTemplate/UpdateEmailTemplateHandlerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Unit\Services\Application\Handlers\EmailTemplate;
+
+use HiEvents\DomainObjects\EmailTemplateDomainObject;
+use HiEvents\DomainObjects\Enums\EmailTemplateType;
+use HiEvents\Repository\Interfaces\EmailTemplateRepositoryInterface;
+use HiEvents\Services\Application\Handlers\EmailTemplate\DTO\UpsertEmailTemplateDTO;
+use HiEvents\Services\Application\Handlers\EmailTemplate\UpdateEmailTemplateHandler;
+use HiEvents\Services\Domain\Email\EmailTemplateService;
+use HiEvents\Services\Infrastructure\HtmlPurifier\HtmlPurifierService;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class UpdateEmailTemplateHandlerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private EmailTemplateRepositoryInterface $repository;
+
+    private EmailTemplateService $emailTemplateService;
+
+    private HtmlPurifierService $purifier;
+
+    private UpdateEmailTemplateHandler $handler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = m::mock(EmailTemplateRepositoryInterface::class);
+        $this->emailTemplateService = m::mock(EmailTemplateService::class);
+        $this->purifier = m::mock(HtmlPurifierService::class);
+
+        $this->handler = new UpdateEmailTemplateHandler(
+            $this->repository,
+            $this->emailTemplateService,
+            $this->purifier,
+        );
+    }
+
+    public function test_attendee_ticket_template_keeps_ticket_url_token_when_caller_passes_no_token(): void
+    {
+        $existing = (new EmailTemplateDomainObject)
+            ->setId(42)
+            ->setAccountId(1)
+            ->setTemplateType(EmailTemplateType::ATTENDEE_TICKET->value);
+
+        $this->emailTemplateService
+            ->shouldReceive('validateTemplate')
+            ->andReturn(['valid' => true, 'errors' => []]);
+
+        $this->repository
+            ->shouldReceive('findFirstWhere')
+            ->andReturn($existing);
+
+        $this->emailTemplateService
+            ->shouldReceive('getDefaultTemplate')
+            ->with(EmailTemplateType::ATTENDEE_TICKET)
+            ->andReturn([
+                'subject' => 's',
+                'body' => 'b',
+                'cta' => ['label' => 'View Ticket', 'url_token' => 'ticket.url'],
+            ]);
+
+        $this->purifier->shouldReceive('purify')->andReturnUsing(fn ($v) => $v);
+
+        $this->repository
+            ->shouldReceive('updateFromArray')
+            ->once()
+            ->with(42, m::on(function (array $payload): bool {
+                return $payload['cta'] === ['label' => 'My Custom Label', 'url_token' => 'ticket.url'];
+            }))
+            ->andReturn($existing);
+
+        $this->handler->handle(new UpsertEmailTemplateDTO(
+            account_id: 1,
+            template_type: EmailTemplateType::ORDER_CONFIRMATION,
+            subject: 'subj',
+            body: 'body',
+            id: 42,
+            cta: ['label' => 'My Custom Label'],
+        ));
+    }
+
+    public function test_attendee_ticket_template_overrides_order_url_token_passed_in(): void
+    {
+        $existing = (new EmailTemplateDomainObject)
+            ->setId(42)
+            ->setAccountId(1)
+            ->setTemplateType(EmailTemplateType::ATTENDEE_TICKET->value);
+
+        $this->emailTemplateService
+            ->shouldReceive('validateTemplate')
+            ->andReturn(['valid' => true, 'errors' => []]);
+
+        $this->repository
+            ->shouldReceive('findFirstWhere')
+            ->andReturn($existing);
+
+        $this->emailTemplateService
+            ->shouldReceive('getDefaultTemplate')
+            ->with(EmailTemplateType::ATTENDEE_TICKET)
+            ->andReturn([
+                'subject' => 's',
+                'body' => 'b',
+                'cta' => ['label' => 'View Ticket', 'url_token' => 'ticket.url'],
+            ]);
+
+        $this->purifier->shouldReceive('purify')->andReturnUsing(fn ($v) => $v);
+
+        $this->repository
+            ->shouldReceive('updateFromArray')
+            ->once()
+            ->with(42, m::on(function (array $payload): bool {
+                return $payload['cta']['url_token'] === 'ticket.url';
+            }))
+            ->andReturn($existing);
+
+        $this->handler->handle(new UpsertEmailTemplateDTO(
+            account_id: 1,
+            template_type: EmailTemplateType::ORDER_CONFIRMATION,
+            subject: 'subj',
+            body: 'body',
+            id: 42,
+            cta: ['label' => 'View Ticket', 'url_token' => 'order.url'],
+        ));
+    }
+
+    public function test_order_confirmation_template_uses_order_url_token(): void
+    {
+        $existing = (new EmailTemplateDomainObject)
+            ->setId(43)
+            ->setAccountId(1)
+            ->setTemplateType(EmailTemplateType::ORDER_CONFIRMATION->value);
+
+        $this->emailTemplateService
+            ->shouldReceive('validateTemplate')
+            ->andReturn(['valid' => true, 'errors' => []]);
+
+        $this->repository
+            ->shouldReceive('findFirstWhere')
+            ->andReturn($existing);
+
+        $this->emailTemplateService
+            ->shouldReceive('getDefaultTemplate')
+            ->with(EmailTemplateType::ORDER_CONFIRMATION)
+            ->andReturn([
+                'subject' => 's',
+                'body' => 'b',
+                'cta' => ['label' => 'View Order & Tickets', 'url_token' => 'order.url'],
+            ]);
+
+        $this->purifier->shouldReceive('purify')->andReturnUsing(fn ($v) => $v);
+
+        $this->repository
+            ->shouldReceive('updateFromArray')
+            ->once()
+            ->with(43, m::on(function (array $payload): bool {
+                return $payload['cta']['url_token'] === 'order.url'
+                    && $payload['cta']['label'] === 'View Order';
+            }))
+            ->andReturn($existing);
+
+        $this->handler->handle(new UpsertEmailTemplateDTO(
+            account_id: 1,
+            template_type: EmailTemplateType::ORDER_CONFIRMATION,
+            subject: 'subj',
+            body: 'body',
+            id: 43,
+            cta: ['label' => 'View Order'],
+        ));
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## What changes I've made

File: backend/app/Services/Application/Handlers/EmailTemplate/UpdateEmailTemplateHandler.php
Change: New resolveCta() derives url_token from existing template's type via EmailTemplateService::getDefaultTemplate()
────────────────────────────────────────
File: backend/app/Http/Actions/EmailTemplates/UpdateEventEmailTemplateAction.php
Change: Pass only label in CTA; handler is authoritative
────────────────────────────────────────
File: backend/app/Http/Actions/EmailTemplates/UpdateOrganizerEmailTemplateAction.php
Change: Same
────────────────────────────────────────
File: backend/app/Console/Commands/RepairEmailTemplateCtaCommand.php
Change: New email-templates:repair-cta-url-token artisan command (--dry-run supported)
────────────────────────────────────────
File: backend/tests/Unit/Services/Application/Handlers/EmailTemplate/UpdateEmailTemplateHandlerTest.php
Change: 3 new unit tests

## Why I've made these changes
When user modifies the custom email template for Attendees, the "View Ticket" call-to-action button gets clobbered and routes to order summary page instead of view-ticket.  Code was commented out for some reason, perhaps intentional? I changed it in my instance and now "View Ticket" correctly routes to "view ticket" page in presence of custom attendee email template.  

### State Before
```
# The comment never became code. The frontend (EmailTemplateEditor.tsx) only collects the label, so there was no client-  side override either — every update silently rewrote url_token to order.url regardless of template type.

$cta = [
    'label' => $validated['ctaLabel'],
    'url_token' => 'order.url', // This will be determined by template type during update
];
```
    
## Notes
 * This was discovered on a production instance where every attendee_ticket template's "View Ticket" button silently routed to the order summary page. After deploying this fix, the bug stops on first save; existing corrupted rows can either (a) be re-saved in the UI or (b) batched via the new artisan command.
 
## How I've tested these changes

*  php artisan test --filter=UpdateEmailTemplateHandlerTest — 3 passed
*  php artisan test --testsuite=Unit --filter='EmailTemplate' — 9 passed
*  php artisan email-templates:repair-cta-url-token --dry-run runs cleanly on a fresh dev DB
* On a deployment with corrupted rows: re-saving an attendee_ticket template via the admin UI restores its CTA to point at the ticket page (no SQL needed).
* Open a new attendee email; confirm the "View Ticket" CTA URL matches /product/{eventId}/{attendeeShortId}.

## Checklist

- [x ] I have read the [contributing guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md).
- [x] My code follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.
- [x] I understand that this PR will be closed if I do not follow the [contributor guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md) and if this PR template is left unedited.
