### PR TITLE
test(email-templates): align token assertions with current dot-notation tokens 🤖

### DIFF
--- a/backend/tests/Feature/Http/Actions/EmailTemplates/EmailTemplateTokenTest.php
+++ b/backend/tests/Feature/Http/Actions/EmailTemplates/EmailTemplateTokenTest.php
@@ -68,11 +68,11 @@ class EmailTemplateTokenTest extends TestCase
         $tokens = $response->json('tokens');
         $this->assertNotEmpty($tokens);
 
-        $firstNameToken = collect($tokens)->firstWhere('token', '{{ order_first_name }}');
+        $firstNameToken = collect($tokens)->firstWhere('token', '{{ order.first_name }}');
         $this->assertNotNull($firstNameToken);
         $this->assertEquals('The first name of the person who placed the order', $firstNameToken['description']);
 
-        $lastNameToken = collect($tokens)->firstWhere('token', '{{ order_last_name }}');
+        $lastNameToken = collect($tokens)->firstWhere('token', '{{ order.last_name }}');
         $this->assertNotNull($lastNameToken);
         $this->assertEquals('The last name of the person who placed the order', $lastNameToken['description']);
     }
@@ -97,7 +97,7 @@ class EmailTemplateTokenTest extends TestCase
         $tokens = $response->json('tokens');
         $this->assertNotEmpty($tokens);
 
-        $attendeeNameToken = collect($tokens)->firstWhere('token', '{{ attendee_name }}');
+        $attendeeNameToken = collect($tokens)->firstWhere('token', '{{ attendee.name }}');
         $this->assertNotNull($attendeeNameToken);
     }
 
@@ -128,10 +128,10 @@ class EmailTemplateTokenTest extends TestCase
         $tokens = $response->json('tokens');
         $tokenNames = collect($tokens)->pluck('token')->toArray();
         
-        $this->assertContains('{{ event_title }}', $tokenNames);
-        $this->assertContains('{{ order_number }}', $tokenNames);
-        $this->assertContains('{{ order_total }}', $tokenNames);
-        $this->assertContains('{{ organizer_name }}', $tokenNames);
+        $this->assertContains('{{ event.title }}', $tokenNames);
+        $this->assertContains('{{ order.number }}', $tokenNames);
+        $this->assertContains('{{ order.total }}', $tokenNames);
+        $this->assertContains('{{ organizer.name }}', $tokenNames);
     }
 
     public function test_tokens_have_proper_structure(): void


### PR DESCRIPTION
## What changes I've made

AI noticed that certain tests were failing on develop branch due to code refactoring from snake_case to dot.notaion in `EmailTemplageTokenTest`  This patch updates those tests. 

  `EmailTemplateTokenTest` asserts old underscore-style token names (`{{ order_first_name }}`, `{{ attendee_name }}`, `{{ event_title
   }}`, `{{ order_number }}`, `{{ order_total }}`, `{{ organizer_name }}`, `{{ order_last_name }}`) but
  `LiquidTemplateRenderer::getAvailableTokens` has been emitting dot-notation tokens (`{{ order.first_name }}`, `{{ attendee.name
  }}`, `{{ event.title }}`, etc.) since the format was refactored. The test was never updated, so 3 of its 6 cases have been failing
  on `develop` for a while:

  - `test_can_get_order_confirmation_tokens` (asserts `{{ order_first_name }}` exists)
  - `test_can_get_attendee_ticket_tokens` (asserts `{{ attendee_name }}` exists)
  - `test_tokens_include_order_specific_tokens` (asserts `{{ event_title }}` etc. exist)

  This PR updates the assertions to match the actual emitted tokens. **No production code change** — purely test alignment.

## How I've tested these changes
  - [x] `php artisan test --filter=EmailTemplateTokenTest` — 6 passed (was 3 failed)
 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md).
- [x] My code follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.
- [x] I understand that this PR will be closed if I do not follow the [contributor guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md) and if this PR template is left unedited.
