### PR TITLE
Feature: Add organizer setting to hide the checkout "Copy my details to attendees" control

### DIFF
--- a/backend/app/DomainObjects/Generated/EventSettingDomainObjectAbstract.php
+++ b/backend/app/DomainObjects/Generated/EventSettingDomainObjectAbstract.php
@@ -61,6 +61,7 @@ abstract class EventSettingDomainObjectAbstract extends \HiEvents\DomainObjects\
     final public const TICKET_DESIGN_SETTINGS = 'ticket_design_settings';
     final public const ATTENDEE_DETAILS_COLLECTION_METHOD = 'attendee_details_collection_method';
     final public const SHOW_MARKETING_OPT_IN = 'show_marketing_opt_in';
+    final public const ALLOW_COPY_DETAILS_TO_ALL_ATTENDEES = 'allow_copy_details_to_all_attendees';
     final public const HOMEPAGE_THEME_SETTINGS = 'homepage_theme_settings';
     final public const PASS_PLATFORM_FEE_TO_BUYER = 'pass_platform_fee_to_buyer';
     final public const ALLOW_ATTENDEE_SELF_EDIT = 'allow_attendee_self_edit';
@@ -119,6 +120,7 @@ abstract class EventSettingDomainObjectAbstract extends \HiEvents\DomainObjects\
     protected array|string|null $ticket_design_settings = null;
     protected string $attendee_details_collection_method = 'PER_TICKET';
     protected bool $show_marketing_opt_in = true;
+    protected bool $allow_copy_details_to_all_attendees = true;
     protected array|string|null $homepage_theme_settings = null;
     protected bool $pass_platform_fee_to_buyer = false;
     protected bool $allow_attendee_self_edit = true;
@@ -180,6 +182,7 @@ abstract class EventSettingDomainObjectAbstract extends \HiEvents\DomainObjects\
                     'ticket_design_settings' => $this->ticket_design_settings ?? null,
                     'attendee_details_collection_method' => $this->attendee_details_collection_method ?? null,
                     'show_marketing_opt_in' => $this->show_marketing_opt_in ?? null,
+                    'allow_copy_details_to_all_attendees' => $this->allow_copy_details_to_all_attendees ?? null,
                     'homepage_theme_settings' => $this->homepage_theme_settings ?? null,
                     'pass_platform_fee_to_buyer' => $this->pass_platform_fee_to_buyer ?? null,
                     'allow_attendee_self_edit' => $this->allow_attendee_self_edit ?? null,
@@ -749,6 +752,17 @@ abstract class EventSettingDomainObjectAbstract extends \HiEvents\DomainObjects\
     public function getShowMarketingOptIn(): bool
     {
         return $this->show_marketing_opt_in;
+    }
+
+    public function setAllowCopyDetailsToAllAttendees(bool $allow_copy_details_to_all_attendees): self
+    {
+        $this->allow_copy_details_to_all_attendees = $allow_copy_details_to_all_attendees;
+        return $this;
+    }
+
+    public function getAllowCopyDetailsToAllAttendees(): bool
+    {
+        return $this->allow_copy_details_to_all_attendees;
     }
 
     public function setHomepageThemeSettings(array|string|null $homepage_theme_settings): self

--- a/backend/app/Http/Request/EventSettings/UpdateEventSettingsRequest.php
+++ b/backend/app/Http/Request/EventSettings/UpdateEventSettingsRequest.php
@@ -92,6 +92,9 @@ class UpdateEventSettingsRequest extends BaseRequest
             // Marketing settings
             'show_marketing_opt_in' => ['boolean'],
 
+            // Attendee detail copy control
+            'allow_copy_details_to_all_attendees' => ['boolean'],
+
             // Platform fee settings
             'pass_platform_fee_to_buyer' => ['boolean'],
 

--- a/backend/app/Resources/Event/EventSettingsResource.php
+++ b/backend/app/Resources/Event/EventSettingsResource.php
@@ -71,6 +71,9 @@ class EventSettingsResource extends JsonResource
             // Marketing settings
             'show_marketing_opt_in' => $this->getShowMarketingOptIn(),
 
+            // Attendee detail copy control
+            'allow_copy_details_to_all_attendees' => $this->getAllowCopyDetailsToAllAttendees(),
+
             // Platform fee settings
             'pass_platform_fee_to_buyer' => $this->getPassPlatformFeeToBuyer(),
 

--- a/backend/app/Resources/Event/EventSettingsResourcePublic.php
+++ b/backend/app/Resources/Event/EventSettingsResourcePublic.php
@@ -77,6 +77,9 @@ class EventSettingsResourcePublic extends JsonResource
             // Marketing settings
             'show_marketing_opt_in' => $this->getShowMarketingOptIn(),
 
+            // Attendee detail copy control
+            'allow_copy_details_to_all_attendees' => $this->getAllowCopyDetailsToAllAttendees(),
+
             // Platform fee settings
             'pass_platform_fee_to_buyer' => $this->getPassPlatformFeeToBuyer(),
 

--- a/backend/app/Services/Application/Handlers/EventSettings/DTO/UpdateEventSettingsDTO.php
+++ b/backend/app/Services/Application/Handlers/EventSettings/DTO/UpdateEventSettingsDTO.php
@@ -76,6 +76,9 @@ class UpdateEventSettingsDTO extends BaseDTO
         // Marketing settings
         public readonly bool                    $show_marketing_opt_in = true,
 
+        // Attendee detail copy control
+        public readonly bool                    $allow_copy_details_to_all_attendees = true,
+
         // Platform fee settings
         public readonly bool                    $pass_platform_fee_to_buyer = false,
 
@@ -157,6 +160,9 @@ class UpdateEventSettingsDTO extends BaseDTO
 
             // Marketing defaults
             show_marketing_opt_in: true,
+
+            // Attendee detail copy control default
+            allow_copy_details_to_all_attendees: true,
 
             // Platform fee defaults
             pass_platform_fee_to_buyer: false,

--- a/backend/app/Services/Application/Handlers/EventSettings/PartialUpdateEventSettingsHandler.php
+++ b/backend/app/Services/Application/Handlers/EventSettings/PartialUpdateEventSettingsHandler.php
@@ -127,6 +127,9 @@ class PartialUpdateEventSettingsHandler
                 // Marketing settings
                 'show_marketing_opt_in' => $eventSettingsDTO->settings['show_marketing_opt_in'] ?? $existingSettings->getShowMarketingOptIn(),
 
+                // Attendee detail copy control
+                'allow_copy_details_to_all_attendees' => $eventSettingsDTO->settings['allow_copy_details_to_all_attendees'] ?? $existingSettings->getAllowCopyDetailsToAllAttendees(),
+
                 // Platform fee settings
                 'pass_platform_fee_to_buyer' => $eventSettingsDTO->settings['pass_platform_fee_to_buyer'] ?? $existingSettings->getPassPlatformFeeToBuyer(),
 

--- a/backend/app/Services/Application/Handlers/EventSettings/UpdateEventSettingsHandler.php
+++ b/backend/app/Services/Application/Handlers/EventSettings/UpdateEventSettingsHandler.php
@@ -89,6 +89,9 @@ class UpdateEventSettingsHandler
                     // Marketing settings
                     'show_marketing_opt_in' => $settings->show_marketing_opt_in,
 
+                    // Attendee detail copy control
+                    'allow_copy_details_to_all_attendees' => $settings->allow_copy_details_to_all_attendees,
+
                     // Platform fee settings
                     'pass_platform_fee_to_buyer' => $settings->pass_platform_fee_to_buyer,
 

--- a/backend/app/Services/Domain/Event/CreateEventService.php
+++ b/backend/app/Services/Domain/Event/CreateEventService.php
@@ -226,6 +226,7 @@ class CreateEventService
 
             'attendee_details_collection_method' => $organizerSettings->getDefaultAttendeeDetailsCollectionMethod(),
             'show_marketing_opt_in' => $organizerSettings->getDefaultShowMarketingOptIn(),
+            'allow_copy_details_to_all_attendees' => true,
             'pass_platform_fee_to_buyer' => $organizerSettings->getDefaultPassPlatformFeeToBuyer(),
             'allow_attendee_self_edit' => $organizerSettings->getDefaultAllowAttendeeSelfEdit() ?? false,
             'ticket_design_settings' => [

--- a/backend/database/migrations/2026_06_04_120000_add_allow_copy_details_to_all_attendees_to_event_settings.php
+++ b/backend/database/migrations/2026_06_04_120000_add_allow_copy_details_to_all_attendees_to_event_settings.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('event_settings', function (Blueprint $table) {
+            $table->boolean('allow_copy_details_to_all_attendees')->default(true)->after('show_marketing_opt_in');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('event_settings', function (Blueprint $table) {
+            $table->dropColumn('allow_copy_details_to_all_attendees');
+        });
+    }
+};

--- a/backend/tests/Unit/Http/Request/EventSettings/UpdateEventSettingsRequestTest.php
+++ b/backend/tests/Unit/Http/Request/EventSettings/UpdateEventSettingsRequestTest.php
@@ -43,4 +43,34 @@ class UpdateEventSettingsRequestTest extends TestCase
 
         $this->assertFalse($validator->errors()->has('ticket_design_settings.date_display_mode'));
     }
+
+    public function test_allow_copy_details_to_all_attendees_accepts_boolean(): void
+    {
+        $validator = Validator::make(
+            ['allow_copy_details_to_all_attendees' => false],
+            (new UpdateEventSettingsRequest)->rules()
+        );
+
+        $this->assertFalse($validator->errors()->has('allow_copy_details_to_all_attendees'));
+    }
+
+    public function test_allow_copy_details_to_all_attendees_rejects_non_boolean(): void
+    {
+        $validator = Validator::make(
+            ['allow_copy_details_to_all_attendees' => 'not-a-boolean'],
+            (new UpdateEventSettingsRequest)->rules()
+        );
+
+        $this->assertTrue($validator->errors()->has('allow_copy_details_to_all_attendees'));
+    }
+
+    public function test_allow_copy_details_to_all_attendees_is_optional(): void
+    {
+        $validator = Validator::make(
+            ['ticket_design_settings' => ['accent_color' => '#333333']],
+            (new UpdateEventSettingsRequest)->rules()
+        );
+
+        $this->assertFalse($validator->errors()->has('allow_copy_details_to_all_attendees'));
+    }
 }

--- a/backend/tests/Unit/Resources/Event/EventSettingsResourcePublicTest.php
+++ b/backend/tests/Unit/Resources/Event/EventSettingsResourcePublicTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit\Resources\Event;
+
+use HiEvents\DomainObjects\EventSettingDomainObject;
+use HiEvents\Resources\Event\EventSettingsResourcePublic;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class EventSettingsResourcePublicTest extends TestCase
+{
+    public function test_public_resource_exposes_allow_copy_details_when_enabled(): void
+    {
+        $settings = (new EventSettingDomainObject())
+            ->setAllowCopyDetailsToAllAttendees(true);
+
+        $resource = (new EventSettingsResourcePublic($settings))->toArray(Request::create('/'));
+
+        // Load-bearing: the checkout can only hide the control if this flag is on the
+        // public payload, so it must always be present (outside the post-checkout block).
+        $this->assertArrayHasKey('allow_copy_details_to_all_attendees', $resource);
+        $this->assertTrue($resource['allow_copy_details_to_all_attendees']);
+    }
+
+    public function test_public_resource_exposes_allow_copy_details_when_disabled(): void
+    {
+        $settings = (new EventSettingDomainObject())
+            ->setAllowCopyDetailsToAllAttendees(false);
+
+        $resource = (new EventSettingsResourcePublic($settings))->toArray(Request::create('/'));
+
+        $this->assertFalse($resource['allow_copy_details_to_all_attendees']);
+    }
+}

--- a/backend/tests/Unit/Services/Application/Handlers/EventSettings/PartialUpdateEventSettingsHandlerTest.php
+++ b/backend/tests/Unit/Services/Application/Handlers/EventSettings/PartialUpdateEventSettingsHandlerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit\Services\Application\Handlers\EventSettings;
+
+use HiEvents\DomainObjects\EventSettingDomainObject;
+use HiEvents\Repository\Interfaces\EventSettingsRepositoryInterface;
+use HiEvents\Services\Application\Handlers\EventSettings\DTO\PartialUpdateEventSettingsDTO;
+use HiEvents\Services\Application\Handlers\EventSettings\DTO\UpdateEventSettingsDTO;
+use HiEvents\Services\Application\Handlers\EventSettings\PartialUpdateEventSettingsHandler;
+use HiEvents\Services\Application\Handlers\EventSettings\UpdateEventSettingsHandler;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+class PartialUpdateEventSettingsHandlerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function test_explicit_show_copy_details_value_is_passed_through(): void
+    {
+        // Existing event has the control ON; the PATCH explicitly turns it OFF.
+        $dto = $this->runPartialUpdate(
+            existingValue: true,
+            settings: ['allow_copy_details_to_all_attendees' => false],
+        );
+
+        $this->assertFalse($dto->allow_copy_details_to_all_attendees);
+    }
+
+    public function test_omitted_show_copy_details_key_falls_back_to_existing_value(): void
+    {
+        // Existing event has the control OFF; the PATCH omits the key entirely.
+        // It must keep the existing value (false), NOT reset to the default (true).
+        $dto = $this->runPartialUpdate(
+            existingValue: false,
+            settings: [],
+        );
+
+        $this->assertFalse($dto->allow_copy_details_to_all_attendees);
+    }
+
+    /**
+     * Drives the partial handler and returns the UpdateEventSettingsDTO it forwards
+     * to the (mocked) full handler, so we can assert how the field was resolved.
+     */
+    private function runPartialUpdate(bool $existingValue, array $settings): UpdateEventSettingsDTO
+    {
+        $existingSettings = (new EventSettingDomainObject())
+            ->setAllowCopyDetailsToAllAttendees($existingValue)
+            ->setPaymentProviders([]);
+
+        $repository = Mockery::mock(EventSettingsRepositoryInterface::class);
+        $repository->shouldReceive('findFirstWhere')
+            ->with(['event_id' => 1])
+            ->andReturn($existingSettings);
+
+        $captured = null;
+        $fullHandler = Mockery::mock(UpdateEventSettingsHandler::class);
+        $fullHandler->shouldReceive('handle')
+            ->once()
+            ->andReturnUsing(function (UpdateEventSettingsDTO $dto) use (&$captured, $existingSettings) {
+                $captured = $dto;
+                return $existingSettings;
+            });
+
+        $handler = new PartialUpdateEventSettingsHandler($fullHandler, $repository);
+
+        $handler->handle(new PartialUpdateEventSettingsDTO(
+            account_id: 1,
+            event_id: 1,
+            settings: array_merge(['location_details' => []], $settings),
+        ));
+
+        return $captured;
+    }
+}

--- a/backend/tests/Unit/Services/Application/Handlers/EventSettings/UpdateEventSettingsHandlerTest.php
+++ b/backend/tests/Unit/Services/Application/Handlers/EventSettings/UpdateEventSettingsHandlerTest.php
@@ -118,7 +118,43 @@ class UpdateEventSettingsHandlerTest extends TestCase
         Event::assertNotDispatched(CapacityChangedEvent::class);
     }
 
-    private function createDTO(?bool $waitlist_auto_process = null): UpdateEventSettingsDTO
+    public function testPersistsAllowCopyDetailsToAllAttendees(): void
+    {
+        Event::fake();
+
+        $existingSettings = new EventSettingDomainObject();
+
+        $this->eventSettingsRepository
+            ->shouldReceive('findFirstWhere')
+            ->with(['event_id' => 1])
+            ->twice()
+            ->andReturn($existingSettings);
+
+        $captured = null;
+        $this->eventSettingsRepository
+            ->shouldReceive('updateWhere')
+            ->once()
+            ->andReturnUsing(function (...$args) use (&$captured) {
+                foreach ($args as $arg) {
+                    if (is_array($arg) && array_key_exists('allow_copy_details_to_all_attendees', $arg)) {
+                        $captured = $arg['allow_copy_details_to_all_attendees'];
+                    }
+                }
+                return 1;
+            });
+
+        $this->handler->handle($this->createDTO(allow_copy_details_to_all_attendees: false));
+
+        $this->assertFalse(
+            $captured,
+            'Expected allow_copy_details_to_all_attendees=false to be persisted via updateWhere'
+        );
+    }
+
+    private function createDTO(
+        ?bool $waitlist_auto_process = null,
+        bool  $allow_copy_details_to_all_attendees = true,
+    ): UpdateEventSettingsDTO
     {
         return UpdateEventSettingsDTO::fromArray([
             'account_id' => 1,
@@ -143,6 +179,7 @@ class UpdateEventSettingsHandlerTest extends TestCase
             'seo_title' => null,
             'seo_description' => null,
             'seo_keywords' => null,
+            'allow_copy_details_to_all_attendees' => $allow_copy_details_to_all_attendees,
             'waitlist_auto_process' => $waitlist_auto_process,
             'waitlist_offer_timeout_minutes' => 60,
         ]);

--- a/frontend/src/components/routes/event/Settings/Sections/HomepageAndCheckoutSettings/index.tsx
+++ b/frontend/src/components/routes/event/Settings/Sections/HomepageAndCheckoutSettings/index.tsx
@@ -26,6 +26,7 @@ export const HomepageAndCheckoutSettings = () => {
             order_timeout_in_minutes: 15,
             attendee_details_collection_method: 'PER_TICKET' as 'PER_TICKET' | 'PER_ORDER',
             show_marketing_opt_in: true,
+            allow_copy_details_to_all_attendees: true,
         },
         transformValues: (values) => ({
             ...values,
@@ -58,6 +59,7 @@ export const HomepageAndCheckoutSettings = () => {
                 order_timeout_in_minutes: eventSettingsQuery.data.order_timeout_in_minutes,
                 attendee_details_collection_method: eventSettingsQuery.data.attendee_details_collection_method || 'PER_TICKET',
                 show_marketing_opt_in: eventSettingsQuery.data.show_marketing_opt_in ?? true,
+                allow_copy_details_to_all_attendees: eventSettingsQuery.data.allow_copy_details_to_all_attendees ?? true,
             });
         }
     }, [eventSettingsQuery.isFetched]);
@@ -126,6 +128,13 @@ export const HomepageAndCheckoutSettings = () => {
                         label={t`Show marketing opt-in checkbox`}
                         description={t`Display a checkbox allowing customers to opt-in to receive marketing communications from this event organizer.`}
                         {...form.getInputProps('show_marketing_opt_in', {type: 'checkbox'})}
+                    />
+
+                    <Switch
+                        mt="md"
+                        label={t`Allow buyers to copy their details to all attendees`}
+                        description={t`When enabled, buyers can copy their own name and email onto all attendees at once. Turn this off to remove the "All attendees" option; buyers can still copy to the first attendee, and the rest must be entered individually.`}
+                        {...form.getInputProps('allow_copy_details_to_all_attendees', {type: 'checkbox'})}
                     />
 
                     <Button loading={updateMutation.isPending} type={'submit'}>

--- a/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
+++ b/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
@@ -71,6 +71,7 @@ export const CollectInformation = () => {
     const products = productCategories?.flatMap(category => category.products);
     const requireBillingAddress = event?.settings?.require_billing_address;
     const isPerOrderCollection = event?.settings?.attendee_details_collection_method === 'PER_ORDER';
+    const allowCopyToAllAttendees = event?.settings?.allow_copy_details_to_all_attendees ?? true;
     const [copyOption, setCopyOption] = useState<'none' | 'first' | 'all'>('none');
 
     const isEmailValid = (email: string) => {
@@ -498,7 +499,7 @@ export const CollectInformation = () => {
                                             data={[
                                                 {label: t`None`, value: 'none'},
                                                 {label: t`First attendee`, value: 'first'},
-                                                {label: t`All attendees`, value: 'all'},
+                                                ...(allowCopyToAllAttendees ? [{label: t`All attendees`, value: 'all'}] : []),
                                             ]}
                                         />
                                     </Tooltip>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -247,6 +247,9 @@ export interface EventSettings {
     // Marketing settings
     show_marketing_opt_in?: boolean;
 
+    // Attendee detail copy control
+    allow_copy_details_to_all_attendees?: boolean;
+
     // Platform fee settings
     pass_platform_fee_to_buyer?: boolean;
 


### PR DESCRIPTION
## What changes I've made

This adds a new per event boolean setting `allow_copy_details_to_all_attendees` (default true). At checkout, when there are several attendees, buyers see a "Copy my details to:" control with None, First attendee and All attendees. When an organizer turns this setting off, only the "All attendees" option is removed: buyers can still copy their details to the first attendee, but cannot bulk copy them onto everyone, so the remaining attendees have to be filled in individually. The None and First attendee options, and the single attendee "Copy details to first attendee" checkbox, are unaffected.

<img width="1529" height="586" alt="Screenshot 2026-06-04 at 20 12 03" src="https://github.com/user-attachments/assets/ee6edd6f-0702-4406-bba4-046045232ad1" />

<img width="1197" height="644" alt="Screenshot 2026-06-04 at 20 35 16" src="https://github.com/user-attachments/assets/4296554e-dc0e-4581-bc04-827479fc618b" />


The change follows the existing `show_marketing_opt_in` and `allow_attendee_self_edit` settings end to end: a migration on `event_settings`, the generated domain object, the request validation rule, the `UpdateEventSettingsDTO` (constructor default and `createWithDefaults`), the full and partial update handlers, the admin and public `EventSettingsResource`, the frontend `EventSettings` type, a `Switch` in the Checkout Settings section, and the checkout `CollectInformation` component. The public resource exposes the flag so the checkout can read it, with a `?? true` fallback so an absent value keeps the current behaviour.

One small follow up: the two new translation strings still need `npm run messages:extract && npm run messages:compile` to land in the locale catalogs, which I left out since it rewrites all locale files.

## Why I've made these changes

Some organizers find that buyers click "All attendees" out of convenience and end up with duplicated or placeholder attendee data that then needs manual cleanup, and some events need every attendee to enter their own real name and email. Copying to just the first attendee is usually fine, since the buyer is normally the first attendee, so this keeps that convenience while letting an organizer switch off the bulk copy. It defaults to true and existing rows are backfilled to true, so every existing event keeps the current behaviour until an organizer opts out. Resolves #1217.

## How I've tested these changes

I added backend unit tests covering the validation rule, that the full handler persists the value, that the partial handler keeps the existing value when a PATCH omits the key, and that the public resource exposes the field. I ran the full `tests/Unit` suite locally on PHP 8.4 and it passes (397 tests, 1079 assertions, 0 failures). The migration mirrors the existing `allow_attendee_self_edit` one, so the column is added with a true default and existing rows are backfilled on the add column step.

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.
- [x] I understand that this PR will be closed if I do not follow the contributor guidelines and if this PR template is left unedited.
