### PR TITLE
🤖 Fix localized delete confirmations

### DIFF
--- a/frontend/src/components/routes/event/Settings/Sections/DangerZoneSettings/index.tsx
+++ b/frontend/src/components/routes/event/Settings/Sections/DangerZoneSettings/index.tsx
@@ -25,7 +25,8 @@ export const DangerZoneSettings = () => {
     const [deleteConfirmation, setDeleteConfirmation] = useState('');
 
     const isArchived = event?.status === EventStatus.ARCHIVED;
-    const isDeleteConfirmed = deleteConfirmation.toLowerCase() === 'delete';
+    const deleteConfirmationPhrase = t`delete`;
+    const isDeleteConfirmed = deleteConfirmation.trim().toLocaleLowerCase() === deleteConfirmationPhrase.toLocaleLowerCase();
 
     const handleDelete = () => {
         const organizerId = event?.organizer?.id;
@@ -98,7 +99,7 @@ export const DangerZoneSettings = () => {
                                     {t`Type "delete" to confirm`}
                                 </Text>
                                 <TextInput
-                                    placeholder={t`delete`}
+                                    placeholder={deleteConfirmationPhrase}
                                     value={deleteConfirmation}
                                     onChange={(e) => setDeleteConfirmation(e.currentTarget.value)}
                                 />

--- a/frontend/src/components/routes/organizer/Settings/Sections/DangerZoneSettings/index.tsx
+++ b/frontend/src/components/routes/organizer/Settings/Sections/DangerZoneSettings/index.tsx
@@ -27,7 +27,8 @@ export const DangerZoneSettings = () => {
     const [deleteConfirmation, setDeleteConfirmation] = useState('');
 
     const isArchived = organizer?.status === OrganizerStatus.ARCHIVED;
-    const isDeleteConfirmed = deleteConfirmation.toLowerCase() === 'delete';
+    const deleteConfirmationPhrase = t`delete`;
+    const isDeleteConfirmed = deleteConfirmation.trim().toLocaleLowerCase() === deleteConfirmationPhrase.toLocaleLowerCase();
 
     const activeOrganizerCount = organizers?.data?.filter(
         org => org.status !== OrganizerStatus.ARCHIVED
@@ -104,7 +105,7 @@ export const DangerZoneSettings = () => {
                                     {t`Type "delete" to confirm`}
                                 </Text>
                                 <TextInput
-                                    placeholder={t`delete`}
+                                    placeholder={deleteConfirmationPhrase}
                                     value={deleteConfirmation}
                                     onChange={(e) => setDeleteConfirmation(e.currentTarget.value)}
                                 />


### PR DESCRIPTION
﻿Fixes #1220.

## What changed

This updates the event and organizer danger-zone delete confirmations so the typed confirmation is compared against the same localized `delete` translation used by the input placeholder.

That means translated confirmation words such as German `löschen` can enable the delete button instead of requiring the English literal `delete`.

## Validation

- `npm run build:csr` passes
- Targeted ESLint on the changed files reports no errors; existing warnings remain in those files
- Full `npm run lint` currently fails on existing repository-wide lint errors unrelated to this patch
- `npm run build-strict:csr` currently fails on existing repository-wide TypeScript errors unrelated to this patch

## Notes

The same hardcoded confirmation pattern existed in both event deletion and organizer deletion, so both were updated for consistency.
