### PR TITLE
Reject negative product quantities on order creation

### DIFF
--- a/backend/app/Services/Domain/Order/OrderCreateRequestValidationService.php
+++ b/backend/app/Services/Domain/Order/OrderCreateRequestValidationService.php
@@ -84,7 +84,7 @@ class OrderCreateRequestValidationService
             'products' => 'required|array',
             'products.*.product_id' => 'required|integer',
             'products.*.quantities' => 'required|array',
-            'products.*.quantities.*.quantity' => 'required|integer',
+            'products.*.quantities.*.quantity' => 'required|integer|min:0',
             'products.*.quantities.*.price_id' => 'required|integer',
             'products.*.quantities.*.price' => 'numeric|min:0',
         ]);

--- a/backend/tests/Unit/Services/Domain/Order/OrderCreateRequestValidationServiceTest.php
+++ b/backend/tests/Unit/Services/Domain/Order/OrderCreateRequestValidationServiceTest.php
@@ -151,6 +151,40 @@ class OrderCreateRequestValidationServiceTest extends TestCase
         $this->service->validateRequestData($eventId, $data);
     }
 
+    public function testNegativeQuantityOnAPriceTierIsRejected(): void
+    {
+        $eventId = 1;
+        $productId = 10;
+        $cheapPriceId = 101;
+        $expensivePriceId = 102;
+
+        $this->setupMocks(
+            eventId: $eventId,
+            productId: $productId,
+            priceIds: [$cheapPriceId, $expensivePriceId],
+            priceLabels: ['Cheap', 'VIP'],
+            availabilities: [
+                ['price_id' => $cheapPriceId, 'quantity_available' => 100, 'quantity_reserved' => 0],
+                ['price_id' => $expensivePriceId, 'quantity_available' => 100, 'quantity_reserved' => 0],
+            ],
+        );
+
+        $data = [
+            'products' => [
+                [
+                    'product_id' => $productId,
+                    'quantities' => [
+                        ['price_id' => $cheapPriceId, 'quantity' => 5],
+                        ['price_id' => $expensivePriceId, 'quantity' => -1],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(ValidationException::class);
+        $this->service->validateRequestData($eventId, $data);
+    }
+
     public function testUnrelatedOverReservedCapacityDoesNotBlockSelectedProduct(): void
     {
         $eventId = 1;


### PR DESCRIPTION
The public order endpoint validated `products.*.quantities.*.quantity` as `required|integer` with no lower bound. A negative quantity on one price tier of a multi-tier product produced negative line totals, driving `total_gross` below zero so the order completed as `NO_PAYMENT_REQUIRED` and issued tickets without payment.

Adds `min:0` to the quantity rule, rejecting negatives at the validation layer while still allowing `0` for unselected tiers. Includes a regression test.

Thanks to @luuhung1217 for reporting.