### PR TITLE
Sanitize question and organizer descriptions on write

### DIFF
--- a/backend/app/Services/Application/Handlers/Organizer/CreateOrganizerHandler.php
+++ b/backend/app/Services/Application/Handlers/Organizer/CreateOrganizerHandler.php
@@ -7,6 +7,7 @@ use HiEvents\DomainObjects\OrganizerDomainObject;
 use HiEvents\Repository\Interfaces\OrganizerRepositoryInterface;
 use HiEvents\Services\Application\Handlers\Organizer\DTO\CreateOrganizerDTO;
 use HiEvents\Services\Domain\Organizer\CreateDefaultOrganizerSettingsService;
+use HiEvents\Services\Infrastructure\HtmlPurifier\HtmlPurifierService;
 use Illuminate\Database\DatabaseManager;
 use Throwable;
 
@@ -16,6 +17,7 @@ class CreateOrganizerHandler
         private readonly OrganizerRepositoryInterface          $organizerRepository,
         private readonly DatabaseManager                       $databaseManager,
         private readonly CreateDefaultOrganizerSettingsService $createDefaultOrganizerSettingsService,
+        private readonly HtmlPurifierService                   $purifier,
     )
     {
     }
@@ -37,7 +39,7 @@ class CreateOrganizerHandler
             'email' => $organizerData->email,
             'phone' => $organizerData->phone,
             'website' => $organizerData->website,
-            'description' => $organizerData->description,
+            'description' => $this->purifier->purify($organizerData->description),
             'account_id' => $organizerData->account_id,
             'timezone' => $organizerData->timezone,
             'currency' => $organizerData->currency,

--- a/backend/app/Services/Application/Handlers/Question/EditQuestionHandler.php
+++ b/backend/app/Services/Application/Handlers/Question/EditQuestionHandler.php
@@ -5,13 +5,14 @@ namespace HiEvents\Services\Application\Handlers\Question;
 use HiEvents\DomainObjects\QuestionDomainObject;
 use HiEvents\Services\Application\Handlers\Question\DTO\UpsertQuestionDTO;
 use HiEvents\Services\Domain\Question\EditQuestionService;
+use HiEvents\Services\Infrastructure\HtmlPurifier\HtmlPurifierService;
 use Throwable;
 
 class EditQuestionHandler
 {
     public function __construct(
         private readonly EditQuestionService $editQuestionService,
-
+        private readonly HtmlPurifierService $purifier,
     )
     {
     }
@@ -30,7 +31,7 @@ class EditQuestionHandler
             ->setRequired($createQuestionDTO->required)
             ->setOptions($createQuestionDTO->options)
             ->setIsHidden($createQuestionDTO->is_hidden)
-            ->setDescription($createQuestionDTO->description);
+            ->setDescription($this->purifier->purify($createQuestionDTO->description));
 
         return $this->editQuestionService->editQuestion(
             question: $question,

--- a/backend/app/Services/Domain/Order/OrderCreateRequestValidationService.php
+++ b/backend/app/Services/Domain/Order/OrderCreateRequestValidationService.php
@@ -84,7 +84,7 @@ class OrderCreateRequestValidationService
             'products' => 'required|array',
             'products.*.product_id' => 'required|integer',
             'products.*.quantities' => 'required|array',
-            'products.*.quantities.*.quantity' => 'required|integer',
+            'products.*.quantities.*.quantity' => 'required|integer|min:0',
             'products.*.quantities.*.price_id' => 'required|integer',
             'products.*.quantities.*.price' => 'numeric|min:0',
         ]);

--- a/backend/tests/Unit/Services/Application/Handlers/Organizer/CreateOrganizerHandlerTest.php
+++ b/backend/tests/Unit/Services/Application/Handlers/Organizer/CreateOrganizerHandlerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Services\Application\Handlers\Organizer;
+
+use HiEvents\DomainObjects\OrganizerDomainObject;
+use HiEvents\Repository\Interfaces\OrganizerRepositoryInterface;
+use HiEvents\Services\Application\Handlers\Organizer\CreateOrganizerHandler;
+use HiEvents\Services\Application\Handlers\Organizer\DTO\CreateOrganizerDTO;
+use HiEvents\Services\Domain\Organizer\CreateDefaultOrganizerSettingsService;
+use HiEvents\Services\Infrastructure\HtmlPurifier\HtmlPurifierService;
+use Illuminate\Database\DatabaseManager;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+class CreateOrganizerHandlerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testDescriptionIsPurifiedOnCreate(): void
+    {
+        $organizerRepository = Mockery::mock(OrganizerRepositoryInterface::class);
+        $databaseManager = Mockery::mock(DatabaseManager::class);
+        $createDefaultOrganizerSettingsService = Mockery::mock(CreateDefaultOrganizerSettingsService::class);
+        $purifier = Mockery::mock(HtmlPurifierService::class);
+
+        $databaseManager->shouldReceive('transaction')->andReturnUsing(fn($callback) => $callback());
+        $purifier->shouldReceive('purify')->andReturnUsing(fn($v) => is_string($v) ? 'PURIFIED:' . $v : $v);
+
+        $organizer = Mockery::mock(OrganizerDomainObject::class);
+        $organizer->shouldReceive('getId')->andReturn(5);
+
+        $capturedAttributes = null;
+        $organizerRepository
+            ->shouldReceive('create')
+            ->once()
+            ->andReturnUsing(function ($attributes) use (&$capturedAttributes, $organizer) {
+                $capturedAttributes = $attributes;
+                return $organizer;
+            });
+
+        $createDefaultOrganizerSettingsService->shouldReceive('createOrganizerSettings')->once();
+        $organizerRepository->shouldReceive('loadRelation')->andReturnSelf();
+        $organizerRepository->shouldReceive('findById')->with(5)->andReturn($organizer);
+
+        $handler = new CreateOrganizerHandler(
+            $organizerRepository,
+            $databaseManager,
+            $createDefaultOrganizerSettingsService,
+            $purifier,
+        );
+
+        $dto = new CreateOrganizerDTO(
+            name: 'Acme',
+            email: 'acme@test.com',
+            account_id: 1,
+            timezone: 'UTC',
+            currency: 'USD',
+            description: '<img src=x onerror=alert(1)>',
+        );
+
+        $handler->handle($dto);
+
+        $this->assertSame('PURIFIED:<img src=x onerror=alert(1)>', $capturedAttributes['description']);
+    }
+}

--- a/backend/tests/Unit/Services/Application/Handlers/Question/EditQuestionHandlerTest.php
+++ b/backend/tests/Unit/Services/Application/Handlers/Question/EditQuestionHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Services\Application\Handlers\Question;
+
+use HiEvents\DomainObjects\Enums\QuestionBelongsTo;
+use HiEvents\DomainObjects\Enums\QuestionTypeEnum;
+use HiEvents\DomainObjects\QuestionDomainObject;
+use HiEvents\Services\Application\Handlers\Question\DTO\UpsertQuestionDTO;
+use HiEvents\Services\Application\Handlers\Question\EditQuestionHandler;
+use HiEvents\Services\Domain\Question\EditQuestionService;
+use HiEvents\Services\Infrastructure\HtmlPurifier\HtmlPurifierService;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+class EditQuestionHandlerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testDescriptionIsPurifiedOnEdit(): void
+    {
+        $editQuestionService = Mockery::mock(EditQuestionService::class);
+        $purifier = Mockery::mock(HtmlPurifierService::class);
+
+        $purifier->shouldReceive('purify')->andReturnUsing(fn($v) => is_string($v) ? 'PURIFIED:' . $v : $v);
+
+        $capturedQuestion = null;
+        $editQuestionService
+            ->shouldReceive('editQuestion')
+            ->once()
+            ->andReturnUsing(function ($question) use (&$capturedQuestion) {
+                $capturedQuestion = $question;
+                return $question;
+            });
+
+        $handler = new EditQuestionHandler($editQuestionService, $purifier);
+
+        $dto = new UpsertQuestionDTO(
+            title: 'Dietary requirements',
+            type: QuestionTypeEnum::SINGLE_LINE_TEXT,
+            required: false,
+            options: null,
+            event_id: 1,
+            product_ids: [],
+            is_hidden: false,
+            belongs_to: QuestionBelongsTo::ORDER,
+            description: '<img src=x onerror=alert(1)>',
+        );
+
+        $handler->handle(7, $dto);
+
+        $this->assertInstanceOf(QuestionDomainObject::class, $capturedQuestion);
+        $this->assertSame('PURIFIED:<img src=x onerror=alert(1)>', $capturedQuestion->getDescription());
+    }
+}

--- a/backend/tests/Unit/Services/Domain/Order/OrderCreateRequestValidationServiceTest.php
+++ b/backend/tests/Unit/Services/Domain/Order/OrderCreateRequestValidationServiceTest.php
@@ -151,6 +151,40 @@ class OrderCreateRequestValidationServiceTest extends TestCase
         $this->service->validateRequestData($eventId, $data);
     }
 
+    public function testNegativeQuantityOnAPriceTierIsRejected(): void
+    {
+        $eventId = 1;
+        $productId = 10;
+        $cheapPriceId = 101;
+        $expensivePriceId = 102;
+
+        $this->setupMocks(
+            eventId: $eventId,
+            productId: $productId,
+            priceIds: [$cheapPriceId, $expensivePriceId],
+            priceLabels: ['Cheap', 'VIP'],
+            availabilities: [
+                ['price_id' => $cheapPriceId, 'quantity_available' => 100, 'quantity_reserved' => 0],
+                ['price_id' => $expensivePriceId, 'quantity_available' => 100, 'quantity_reserved' => 0],
+            ],
+        );
+
+        $data = [
+            'products' => [
+                [
+                    'product_id' => $productId,
+                    'quantities' => [
+                        ['price_id' => $cheapPriceId, 'quantity' => 5],
+                        ['price_id' => $expensivePriceId, 'quantity' => -1],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(ValidationException::class);
+        $this->service->validateRequestData($eventId, $data);
+    }
+
     public function testUnrelatedOverReservedCapacityDoesNotBlockSelectedProduct(): void
     {
         $eventId = 1;


### PR DESCRIPTION
`EditQuestionHandler` and `CreateOrganizerHandler` stored the `description` field without HTML purification, while their create/edit counterparts did. An organizer could store arbitrary HTML/JS that renders raw via `dangerouslySetInnerHTML` on the public checkout (question description) and organizer homepage (organizer description).

Routes both through `HtmlPurifierService`, matching the existing pattern. Includes regression tests.

Thanks to @karthikranga666 for reporting.