### PR TITLE
Prefill public checkout from URL query params (name/email + optional lock)

### DIFF
--- a/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
+++ b/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
@@ -33,6 +33,7 @@ import countries from "../../../../../data/countries.json";
 import classes from "./CollectInformation.module.scss";
 import {trackEvent, AnalyticsEvents} from "../../../../utilites/analytics.ts";
 import {clearWaitlistJoinedForEvent} from "../../../../hooks/useWaitlistJoined.ts";
+import {useCheckoutPrefill, CheckoutPrefill} from "../../../../hooks/useCheckoutPrefill.ts";
 
 const LoadingSkeleton = () =>
     (
@@ -48,6 +49,8 @@ export const CollectInformation = () => {
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const isFromWaitlist = searchParams.get('waitlist') === 'true';
+    const {prefill, lock} = useCheckoutPrefill();
+    const isLocked = (field: keyof CheckoutPrefill) => lock && prefill[field] !== undefined;
     const {
         isFetched: isOrderFetched,
         data: order,
@@ -296,14 +299,33 @@ export const CollectInformation = () => {
 
     useEffect(() => {
         if (isEventFetched && isOrderFetched && isQuestionsFetched && productQuestions && orderQuestions) {
-            const products = createProductsAndQuestions(createProductIdToQuestionMap());
+            const builtProducts = createProductsAndQuestions(createProductIdToQuestionMap());
             const formOrderQuestions = createFormOrderQuestions();
+
+            const orderPrefill = {
+                ...(prefill.first_name !== undefined && {first_name: prefill.first_name}),
+                ...(prefill.last_name !== undefined && {last_name: prefill.last_name}),
+                ...(prefill.email !== undefined && {email: prefill.email, email_confirmation: prefill.email}),
+            };
+
+            const ticketProductIds = new Set(
+                (products ?? [])
+                    .filter(product => product && product.product_type === 'TICKET')
+                    .map(product => product!.id)
+            );
+
+            const prefilledProducts = builtProducts.map((product: any) =>
+                ticketProductIds.has(product.product_id)
+                    ? {...product, ...orderPrefill}
+                    : product
+            );
 
             form.setValues({
                 ...form.values,
-                products: products,
+                products: prefilledProducts,
                 order: {
                     ...form.values.order,
+                    ...orderPrefill,
                     questions: formOrderQuestions,
                 },
             });
@@ -433,12 +455,14 @@ export const CollectInformation = () => {
                             withAsterisk
                             label={t`First Name`}
                             placeholder={t`First name`}
+                            disabled={isLocked('first_name')}
                             {...form.getInputProps("order.first_name")}
                         />
                         <TextInput
                             withAsterisk
                             label={t`Last Name`}
                             placeholder={t`Last Name`}
+                            disabled={isLocked('last_name')}
                             {...form.getInputProps("order.last_name")}
                         />
                     </InputGroup>
@@ -449,6 +473,7 @@ export const CollectInformation = () => {
                             type={"email"}
                             label={t`Email Address`}
                             placeholder={t`Email Address`}
+                            disabled={isLocked('email')}
                             rightSection={isEmailValid(form.values.order.email) ? <EmailCheckIcon/> : null}
                             {...form.getInputProps("order.email")}
                         />
@@ -457,6 +482,7 @@ export const CollectInformation = () => {
                             type={"email"}
                             label={t`Confirm Email Address`}
                             placeholder={t`Confirm Email Address`}
+                            disabled={isLocked('email')}
                             rightSection={isEmailValid(form.values.order.email_confirmation) ? <EmailCheckIcon/> : null}
                             {...form.getInputProps("order.email_confirmation")}
                         />
@@ -645,12 +671,14 @@ export const CollectInformation = () => {
                                                         withAsterisk
                                                         label={t`First Name`}
                                                         placeholder={t`First name`}
+                                                        disabled={isLocked('first_name')}
                                                         {...form.getInputProps(`products.${currentProductIndex}.first_name`)}
                                                     />
                                                     <TextInput
                                                         withAsterisk
                                                         label={t`Last Name`}
                                                         placeholder={t`Last Name`}
+                                                        disabled={isLocked('last_name')}
                                                         {...form.getInputProps(`products.${currentProductIndex}.last_name`)}
                                                     />
                                                 </InputGroup>
@@ -661,6 +689,7 @@ export const CollectInformation = () => {
                                                         type={"email"}
                                                         label={t`Email Address`}
                                                         placeholder={t`Email Address`}
+                                                        disabled={isLocked('email')}
                                                         rightSection={isEmailValid(form.values.products[currentProductIndex]?.email || '') ?
                                                             <EmailCheckIcon/> : null}
                                                         {...form.getInputProps(`products.${currentProductIndex}.email`)}
@@ -670,6 +699,7 @@ export const CollectInformation = () => {
                                                         type={"email"}
                                                         label={t`Confirm Email Address`}
                                                         placeholder={t`Confirm Email Address`}
+                                                        disabled={isLocked('email')}
                                                         rightSection={isEmailValid(form.values.products[currentProductIndex]?.email_confirmation || '') ?
                                                             <EmailCheckIcon/> : null}
                                                         {...form.getInputProps(`products.${currentProductIndex}.email_confirmation`)}

--- a/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
+++ b/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
@@ -315,7 +315,7 @@ export const CollectInformation = () => {
             );
 
             const prefilledProducts = builtProducts.map((product: any) =>
-                ticketProductIds.has(product.product_id)
+                (!isPerOrderCollection && ticketProductIds.has(product.product_id))
                     ? {...product, ...orderPrefill}
                     : product
             );
@@ -330,6 +330,7 @@ export const CollectInformation = () => {
                 },
             });
         }
+        // prefill/lock intentionally omitted: they're memoized off query params that don't change during the page's lifetime
     }, [isEventFetched, isOrderFetched, isQuestionsFetched]);
 
     useEffect(() => {
@@ -488,7 +489,7 @@ export const CollectInformation = () => {
                         />
                     </InputGroup>
 
-                    {orderRequiresAttendeeDetails && !isPerOrderCollection && totalTicketAttendees > 0 && (
+                    {orderRequiresAttendeeDetails && !isPerOrderCollection && totalTicketAttendees > 0 && !lock && (
                         <div className={classes.copyDetailsSection}>
                             {totalTicketAttendees === 1 ? (
                                 <Tooltip

--- a/frontend/src/components/routes/product-widget/SelectProducts/index.tsx
+++ b/frontend/src/components/routes/product-widget/SelectProducts/index.tsx
@@ -37,6 +37,7 @@ import {IconChevronRight, IconX} from "@tabler/icons-react"
 import {getSessionIdentifier} from "../../../../utilites/sessionIdentifier.ts";
 import {Constants} from "../../../../constants.ts";
 import {clearWaitlistJoinedForEvent} from "../../../../hooks/useWaitlistJoined.ts";
+import {CHECKOUT_PREFILL_PARAM_KEYS} from "../../../../hooks/useCheckoutPrefill.ts";
 
 const AFFILIATE_EXPIRY_DAYS = 30;
 
@@ -150,16 +151,29 @@ const SelectProducts = (props: SelectProductsProps) => {
         onSuccess: (data) => queryClient.invalidateQueries()
             .then(() => {
                 const url = '/checkout/' + eventId + '/' + data.data.short_id + '/details';
+
+                // Forward checkout-prefill params (name/email/lock) from the event page
+                // to the details step, since this navigation would otherwise drop them.
+                const sourceParams = new URLSearchParams(window.location.search);
+                const prefillParams = new URLSearchParams();
+                CHECKOUT_PREFILL_PARAM_KEYS.forEach((key) => {
+                    const value = sourceParams.get(key);
+                    if (value !== null) {
+                        prefillParams.set(key, value);
+                    }
+                });
+                const prefillQuery = prefillParams.toString();
+
                 if (props.widgetMode === 'embedded') {
-                    window.open(
-                        url + '?session_identifier=' + data.data.session_identifier + '&utm_source=embedded_widget',
-                        '_blank'
-                    );
+                    const embeddedQuery = 'session_identifier=' + data.data.session_identifier
+                        + '&utm_source=embedded_widget'
+                        + (prefillQuery ? '&' + prefillQuery : '');
+                    window.open(url + '?' + embeddedQuery, '_blank');
                     setOrderInProcessOverlayVisible(true);
                     return;
                 }
 
-                return navigate(url);
+                return navigate(url + (prefillQuery ? '?' + prefillQuery : ''));
             }),
 
         onError: (error: any) => {

--- a/frontend/src/hooks/useCheckoutPrefill.ts
+++ b/frontend/src/hooks/useCheckoutPrefill.ts
@@ -1,0 +1,48 @@
+import {useMemo} from "react";
+import {useSearchParams} from "react-router";
+
+export interface CheckoutPrefill {
+    first_name?: string;
+    last_name?: string;
+    email?: string;
+}
+
+export interface UseCheckoutPrefillResult {
+    prefill: CheckoutPrefill;
+    lock: boolean;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const useCheckoutPrefill = (): UseCheckoutPrefillResult => {
+    const [searchParams] = useSearchParams();
+
+    const firstNameParam = searchParams.get("first_name");
+    const lastNameParam = searchParams.get("last_name");
+    const emailParam = searchParams.get("email");
+    const lockParam = searchParams.get("lock");
+
+    return useMemo(() => {
+        const prefill: CheckoutPrefill = {};
+
+        const firstName = firstNameParam?.trim();
+        if (firstName) {
+            prefill.first_name = firstName;
+        }
+
+        const lastName = lastNameParam?.trim();
+        if (lastName) {
+            prefill.last_name = lastName;
+        }
+
+        const email = emailParam?.trim();
+        if (email && EMAIL_REGEX.test(email)) {
+            prefill.email = email;
+        }
+
+        const hasPrefill = Object.keys(prefill).length > 0;
+        const lock = hasPrefill && (lockParam === "true" || lockParam === "1");
+
+        return {prefill, lock};
+    }, [firstNameParam, lastNameParam, emailParam, lockParam]);
+};

--- a/frontend/src/hooks/useCheckoutPrefill.ts
+++ b/frontend/src/hooks/useCheckoutPrefill.ts
@@ -12,6 +12,11 @@ export interface UseCheckoutPrefillResult {
     lock: boolean;
 }
 
+// Query params the checkout details form reads to prefill itself. Also forwarded
+// from the event page to the details step so prefill survives order creation
+// (see SelectProducts).
+export const CHECKOUT_PREFILL_PARAM_KEYS = ["first_name", "last_name", "email", "lock"] as const;
+
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export const useCheckoutPrefill = (): UseCheckoutPrefillResult => {


### PR DESCRIPTION
## What & why

Integrators that link to or embed the public checkout (a mobile app WebView, a personalized email link) often already know the attendee's name and email, but there's currently no way to pre-fill the checkout "Your Details" form. The fields are controlled Mantine inputs with generated ids, so DOM injection from an embedder is unreliable. This adds opt-in, frontend-only query-param prefill.

> Note: issue creation on this repo appears to be restricted for my account, so I'm opening this directly with a full description per CONTRIBUTING. Happy to move the discussion wherever you prefer, and to adjust the param names / behaviour.

## Behavior

- **Details step** (`/checkout/:eventId/:orderShortId/details`) reads `first_name`, `last_name`, `email` and prefills the buyer's "Your Details" form (and copies to ticket attendees). `email_confirmation` is derived from `email`; a malformed `email` is ignored. Only the `waitlist` param was read here before, so there's no collision.
- **`lock=true`** (or `1`) makes the prefilled fields read-only — per-field: a field locks only if its param was provided. When locked, the "copy details to attendees" control is hidden so locked values can't be blanked.
- **Propagation:** the same params are carried from the event page through order creation to the details step, so `/event/:id/:slug?first_name=…&email=…&lock=true` works — not just a direct checkout deep-link.

## Scope

Frontend-only. No backend, no migrations, no new dependencies, no new translatable strings.

- **New** `frontend/src/hooks/useCheckoutPrefill.ts` — parses/validates the params; exports `CHECKOUT_PREFILL_PARAM_KEYS` as the single source of truth.
- `CollectInformation` — prefill buyer + ticket attendees, per-field lock, hide the copy-control under lock.
- `SelectProducts` — forward the prefill params on the checkout navigation.

`+` in `email` must be percent-encoded (`%2B`), per normal URL query semantics. `npx tsc --noEmit` introduces no new type errors.

## Testing

Manually verified against a local stack (Docker), driving the real event page → select ticket → Continue → details flow, on both a free and a paid event:

| Scenario | Result |
|---|---|
| Full prefill + `lock=true` | ✅ all fields filled + locked; copy-control hidden |
| Full prefill, no lock | ✅ filled + editable; copy-control visible |
| `lock=1` | ✅ locks |
| `lock=false` / other values | ✅ does not lock |
| Email only + lock | ✅ email + confirm locked; names editable |
| Names only (no email) | ✅ names filled; email blank |
| Invalid email | ✅ ignored (field blank + editable) |
| Plus-address, encoded (`%2B`) | ✅ kept |
| Raw `+` in email | ✅ dropped (decodes to space → invalid) |
| Whitespace-only name | ✅ dropped |
| `lock` with no fields | ✅ locks nothing |
| No params | ✅ behavior unchanged |
| Propagation: event → details | ✅ params ride through order creation |
| Multiple attendees (qty 2+) | ✅ each attendee prefilled + locked per-field |

_Screenshots: event page with prefill link, and the resulting locked details page (attached below)._
