### PR TITLE
Fix multi-tenant organiser logos in emails with fallback to Hi.Events…

### DIFF
--- a/backend/resources/views/vendor/mail/html/message.blade.php
+++ b/backend/resources/views/vendor/mail/html/message.blade.php
@@ -1,13 +1,56 @@
 <x-mail::layout>
     {{-- Header --}}
     <x-slot:header>
-        <x-mail::header :url="config('app.email_logo_link_url')">
-            @if($appLogo = config('app.email_logo_url'))
-                <img src="{{ $appLogo }}" class="logo" alt="{{ config('app.name') }}"
-                     style="max-width: 300px;">
+@php
+            $logoPath = null;
+            $organizerName = null;
+            $organizerId = null;
+            
+            // 1. Resolve organizer ID from active variables or fallback request contexts
+            if (isset($event) && $event->organizer) {
+                $organizerId = $event->organizer->id;
+                $organizerName = $event->organizer->name;
+            } elseif (isset($order) && $order->event && $order->event->organizer) {
+                $organizerId = $order->event->organizer->id;
+                $organizerName = $order->event->organizer->name;
+            } else {
+                $eventId = request()->route('event_id') ?? request()->input('event_id') ?? ($order->event_id ?? null);
+                if ($eventId) {
+                    $dbEvent = \DB::table('events')->where('id', $eventId)->first();
+                    if ($dbEvent) {
+                        $organizerId = $dbEvent->organizer_id;
+                    }
+                }
+            }
+
+            // 2. Fetch the true asset path from the custom images ledger if an organizer was resolved
+            if ($organizerId) {
+                if (!$organizerName) {
+                    $dbOrg = \DB::table('organizers')->where('id', $organizerId)->first();
+                    $organizerName = $dbOrg->name ?? null;
+                }
+                
+                $dbImage = \DB::table('images')
+                    ->where('entity_id', $organizerId)
+                    ->where('entity_type', 'HiEvents\DomainObjects\OrganizerDomainObject')
+                    ->first();
+                    
+                if ($dbImage) {
+                    $logoPath = $dbImage->path;
+                }
+            }
+        @endphp
+
+        <x-mail::header :url="config('app.frontend_url')">
+            @if($logoPath)
+                {{-- Render the true dynamic tenant organizer logo asset link --}}
+                <img src="{{ config('app.frontend_url') }}/storage/{{ $logoPath }}" class="logo" alt="{{ $organizerName }}" style="max-width: 300px;">
+            @elseif($appLogo = config('app.email_logo_url'))
+                {{-- Fallback to global setting --}}
+                <img src="{{ $appLogo }}" class="logo" alt="{{ config('app.name') }}" style="max-width: 300px;">
             @else
-                <img src="{{ config('app.frontend_url') }}/logos/hi-events-stacked-light.png" class="logo" alt="{{ config('app.name') }}"
-                     style="max-width: 300px;">
+                {{-- Clean fallback typography --}}
+		<h2 style="margin:0; font-family: sans-serif; color: #333333;">{{ $organizerName ?? env('VITE_APP_NAME', 'Hi.Events') }}</h2>
             @endif
         </x-mail::header>
     </x-slot:header>

--- a/docker/all-in-one/docker-compose.yml
+++ b/docker/all-in-one/docker-compose.yml
@@ -43,7 +43,8 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
       - WEBHOOK_QUEUE_NAME=webhook-queue
-
+    volumes:
+      - appdata:/app/backend/storage
     depends_on:
       postgres:
         condition: service_healthy
@@ -79,3 +80,4 @@ services:
 volumes:
   pgdata:
   redisdata:
+  appdata:


### PR DESCRIPTION
> Please delete everything above this line, then fill in the sections below.

---

## What changes I've made
Fix #1238 broken uploadimages via volume block (appdata) in docker config.    https://github.com/HiEventsDev/Hi.Events/issues/1238

Updated code in message.blade.php to choose the event organizer name and logo before falling back to VITE_APP_NAME and the Hi.Events logo.


## Why I've made these changes
Uploaded images were resulting in broken links to end users.
Hi.Events logo was shown at the top of every email.

## How I've tested these changes
Restarting docker to ensure changes are permanent.  Testing with multiple browsers with cache refreshed.


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md).
- [x] My code follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.
- [x] I understand that this PR will be closed if I do not follow the [contributor guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md) and if this PR template is left unedited.
