### PR TITLE
fix: prevent XSS via event title in inline script contexts

### DIFF
--- a/backend/app/Helper/StringHelper.php
+++ b/backend/app/Helper/StringHelper.php
@@ -4,6 +4,14 @@ namespace HiEvents\Helper;
 
 class StringHelper
 {
+    /**
+     * Remove control characters and unicode line/paragraph separators from a plain-text value.
+     */
+    public static function stripControlCharacters(string $text): string
+    {
+        return preg_replace('/[\x{0000}-\x{001F}\x{007F}-\x{009F}\x{2028}\x{2029}]/u', '', $text) ?? $text;
+    }
+
     public static function previewFromHtml(string $text, int $length = 100): string
     {
         $textWithSpaces = preg_replace('/<[^>]+>/', ' ', $text);

--- a/backend/app/Services/Application/Handlers/Event/UpdateEventHandler.php
+++ b/backend/app/Services/Application/Handlers/Event/UpdateEventHandler.php
@@ -8,6 +8,7 @@ use HiEvents\Events\Dispatcher;
 use HiEvents\Events\EventUpdateEvent;
 use HiEvents\Exceptions\CannotChangeCurrencyException;
 use HiEvents\Helper\DateHelper;
+use HiEvents\Helper\StringHelper;
 use HiEvents\Repository\Interfaces\EventRepositoryInterface;
 use HiEvents\Repository\Interfaces\OrderRepositoryInterface;
 use HiEvents\Services\Application\Handlers\Event\DTO\UpdateEventDTO;
@@ -71,7 +72,7 @@ readonly class UpdateEventHandler
 
         $this->eventRepository->updateWhere(
             attributes: [
-                'title' => $eventData->title,
+                'title' => StringHelper::stripControlCharacters($eventData->title),
                 'category' => $eventData->category?->value ?? $existingEvent->getCategory(),
                 'start_date' => DateHelper::convertToUTC($eventData->start_date, $eventData->timezone),
                 'end_date' => $eventData->end_date

--- a/backend/app/Services/Domain/Event/CreateEventService.php
+++ b/backend/app/Services/Domain/Event/CreateEventService.php
@@ -12,6 +12,7 @@ use HiEvents\DomainObjects\OrganizerSettingDomainObject;
 use HiEvents\Exceptions\OrganizerNotFoundException;
 use HiEvents\Helper\DateHelper;
 use HiEvents\Helper\IdHelper;
+use HiEvents\Helper\StringHelper;
 use HiEvents\Repository\Interfaces\EventRepositoryInterface;
 use HiEvents\Repository\Interfaces\EventSettingsRepositoryInterface;
 use HiEvents\Repository\Interfaces\EventStatisticRepositoryInterface;
@@ -94,7 +95,7 @@ class CreateEventService
     private function handleEventCreate(EventDomainObject $eventData): EventDomainObject
     {
         return $this->eventRepository->create([
-            'title' => $eventData->getTitle(),
+            'title' => StringHelper::stripControlCharacters($eventData->getTitle()),
             'organizer_id' => $eventData->getOrganizerId(),
             'start_date' => DateHelper::convertToUTC($eventData->getStartDate(), $eventData->getTimezone()),
             'end_date' => $eventData->getEndDate()

--- a/backend/app/Services/Domain/Event/DuplicateEventService.php
+++ b/backend/app/Services/Domain/Event/DuplicateEventService.php
@@ -18,6 +18,7 @@ use HiEvents\DomainObjects\QuestionDomainObject;
 use HiEvents\DomainObjects\Status\EventStatus;
 use HiEvents\DomainObjects\TaxAndFeesDomainObject;
 use HiEvents\DomainObjects\WebhookDomainObject;
+use HiEvents\Helper\StringHelper;
 use HiEvents\Repository\Eloquent\Value\Relationship;
 use HiEvents\Repository\Interfaces\AffiliateRepositoryInterface;
 use HiEvents\Repository\Interfaces\EventRepositoryInterface;
@@ -81,7 +82,7 @@ class DuplicateEventService
             $event = $this->getEventWithRelations($eventId, $accountId);
 
             $event
-                ->setTitle($title)
+                ->setTitle(StringHelper::stripControlCharacters($title))
                 ->setStartDate($startDate)
                 ->setEndDate($endDate)
                 ->setDescription($this->purifier->purify($description))

--- a/backend/tests/Unit/Helper/StringHelperTest.php
+++ b/backend/tests/Unit/Helper/StringHelperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Helper;
+
+use HiEvents\Helper\StringHelper;
+use Tests\TestCase;
+
+class StringHelperTest extends TestCase
+{
+    public function testStripControlCharactersRemovesControlAndSeparatorCharacters(): void
+    {
+        $input = "Hello\x00\x1F\x7F\u{2028}\u{2029}World";
+
+        $this->assertSame('HelloWorld', StringHelper::stripControlCharacters($input));
+    }
+
+    public function testStripControlCharactersPreservesLegitimatePrintableCharacters(): void
+    {
+        $input = 'Rock & Roll: a < b > c "Live" 🎸';
+
+        $this->assertSame($input, StringHelper::stripControlCharacters($input));
+    }
+
+    public function testStripControlCharactersPreservesScriptLikeText(): void
+    {
+        // The title is stored faithfully; escaping is the renderer's responsibility.
+        $input = '</script><svg onload=alert(1)>';
+
+        $this->assertSame($input, StringHelper::stripControlCharacters($input));
+    }
+}

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -12,6 +12,7 @@ import * as nodePath from "node:path";
 import * as nodeUrl from "node:url";
 import "dotenv/config";
 import {sitemapIndexHandler, sitemapEventsHandler, sitemapOrganizersHandler} from "./src/sitemap/proxy.js";
+import {htmlSafeJsonStringify} from "./src/utilites/safeScriptJson.js";
 
 installGlobals();
 
@@ -59,7 +60,7 @@ async function main() {
                 envVars[key] = process.env[key];
             }
         }
-        return JSON.stringify(envVars);
+        return htmlSafeJsonStringify(envVars);
     };
 
     app.get('/robots.txt', (req, res) => {
@@ -98,7 +99,7 @@ Sitemap: ${frontendUrl}/sitemap.xml
                 { req, res },
                 ssrManifest
             );
-            const stringifiedState = JSON.stringify(dehydratedState);
+            const stringifiedState = htmlSafeJsonStringify(dehydratedState);
 
             const helmetHtml = Object.values(helmetContext.helmet || {})
                 .map((value) => value.toString() || "")
@@ -114,11 +115,11 @@ Sitemap: ${frontendUrl}/sitemap.xml
             }
 
             const html = template
-                .replace("<!--head-snippets-->", headSnippets.join("\n"))
-                .replace("<!--app-html-->", appHtml)
-                .replace("<!--dehydrated-state-->", `<script>window.__REHYDRATED_STATE__ = ${stringifiedState}</script>`)
-                .replace("<!--environment-variables-->", envVariablesHtml)
-                .replace(/<!--render-helmet-->.*?<!--\/render-helmet-->/s, helmetHtml);
+                .replace("<!--head-snippets-->", () => headSnippets.join("\n"))
+                .replace("<!--app-html-->", () => appHtml)
+                .replace("<!--dehydrated-state-->", () => `<script>window.__REHYDRATED_STATE__ = ${stringifiedState}</script>`)
+                .replace("<!--environment-variables-->", () => envVariablesHtml)
+                .replace(/<!--render-helmet-->.*?<!--\/render-helmet-->/s, () => helmetHtml);
 
             res.setHeader("Content-Type", "text/html");
             return res.status(200).end(html);

--- a/frontend/src/components/common/EventDocumentHead/index.tsx
+++ b/frontend/src/components/common/EventDocumentHead/index.tsx
@@ -3,6 +3,7 @@ import {Helmet} from "react-helmet-async";
 import {Event} from "../../../types";
 import {eventCoverImageUrl, eventHomepageUrl} from "../../../utilites/urlHelper.ts";
 import {utcToTz} from "../../../utilites/dates.ts";
+import {htmlSafeJsonStringify} from "../../../utilites/safeScriptJson.js";
 
 interface EventDocumentHeadProps {
     event: Event;
@@ -90,7 +91,7 @@ export const EventDocumentHead = ({event}: EventDocumentHeadProps) => {
             <link rel="canonical" href={url}/>
 
             <script type="application/ld+json">
-                {JSON.stringify(schemaOrgJSONLD)}
+                {htmlSafeJsonStringify(schemaOrgJSONLD)}
             </script>
         </Helmet>
     );

--- a/frontend/src/utilites/safeScriptJson.d.ts
+++ b/frontend/src/utilites/safeScriptJson.d.ts
@@ -1,0 +1,1 @@
+export declare const htmlSafeJsonStringify: (value: unknown) => string;

--- a/frontend/src/utilites/safeScriptJson.js
+++ b/frontend/src/utilites/safeScriptJson.js
@@ -1,0 +1,10 @@
+/**
+ * Serialise a value to JSON that is safe to embed inside an inline <script> tag.
+ */
+export const htmlSafeJsonStringify = (value) =>
+    (JSON.stringify(value) ?? "null")
+        .replace(/</g, "\\u003c")
+        .replace(/>/g, "\\u003e")
+        .replace(/&/g, "\\u0026")
+        .replace(/\u2028/g, "\\u2028")
+        .replace(/\u2029/g, "\\u2029");


### PR DESCRIPTION
Escapes user-controlled data before embedding it in inline `<script>` tags (rehydrated state, JSON-LD, env vars) so an event title can't break out of the script context. Uses function replacements in the SSR template so `$` sequences in the data aren't interpreted, and strips control characters from titles as defence-in-depth.

Thanks to @0xh3lix for the report.
