### PR TITLE
docs: add RepoCloud as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Built with **Laravel 13** (PHP >=8.3) · **React 19** with SSR · **TypeScript**
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://github.com/HiEventsDev/hi.events-render.com)
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/8CGKmu?referralCode=KvSr11)
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/8DIRY6)
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Hi.Events/)
 
 ### Docker
 


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option alongside the existing providers (DigitalOcean, Render, Railway, Zeabur).

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment.

- Adds deploy button to `README.md`
- Links to: https://repocloud.io/details/Hi.Events/