### PR TITLE
Fix: Add-on highlight message overflows and crushes the add-on title

### DIFF
--- a/frontend/src/components/routes/product-widget/SelectProducts/index.tsx
+++ b/frontend/src/components/routes/product-widget/SelectProducts/index.tsx
@@ -836,13 +836,13 @@ const SelectProducts = (props: SelectProductsProps) => {
                                                             return (
                                                                 <div key={addonId}
                                                                      className={classNames('hi-product-addon', addon.is_highlighted && 'hi-product-addon-highlighted')}>
+                                                                    {addon.is_highlighted && addon.highlight_message && (
+                                                                        <div className={'hi-product-addon-highlight-message'}>
+                                                                            {addon.highlight_message}
+                                                                        </div>
+                                                                    )}
                                                                     <div className={'hi-product-addon-title'}>
                                                                         {addon.title}
-                                                                        {addon.is_highlighted && addon.highlight_message && (
-                                                                            <span className={'hi-product-addon-highlight-message'}>
-                                                                                {addon.highlight_message}
-                                                                            </span>
-                                                                        )}
                                                                     </div>
                                                                     <TieredPricing
                                                                         productIndex={addonFormIndex}

--- a/frontend/src/styles/widget/default.scss
+++ b/frontend/src/styles/widget/default.scss
@@ -503,25 +503,10 @@
       }
 
       .hi-product-addon-title {
-        display: flex;
-        align-items: center;
-        gap: 8px;
         font-weight: 600;
         font-size: 13.5px;
         margin-bottom: 2px;
         overflow-wrap: anywhere;
-      }
-
-      .hi-product-addon-highlight-message {
-        background: var(--hi-accent);
-        color: var(--hi-accent-contrast);
-        font-size: 10px;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        padding: 2px 8px;
-        border-radius: 999px;
-        white-space: nowrap;
       }
 
       &.hi-product-addon-highlighted {
@@ -529,7 +514,23 @@
         margin-right: -10px;
         padding: 8px 10px;
         border-radius: 10px;
+        border: 1px solid color-mix(in srgb, var(--hi-accent) 35%, transparent);
         background-color: var(--hi-soft-accent);
+        overflow: hidden;
+      }
+
+      .hi-product-addon-highlight-message {
+        background: var(--hi-accent);
+        color: var(--hi-accent-contrast);
+        font-size: 10.5px;
+        font-weight: 700;
+        line-height: 1.4;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        text-align: center;
+        overflow-wrap: anywhere;
+        padding: 4px 10px;
+        margin: -8px -10px 8px;
       }
 
       .hi-product-addon-description {


### PR DESCRIPTION
## Issue this fixes

The add-on highlight message (`hi-product-addon-highlight-message`, introduced with product add-ons in #1300) was rendered as a `white-space: nowrap` pill inside the add-on title's flex row. Any message of real length competed with the title for width, so on mobile it either clipped past the card edge or crushed the title onto several lines. It also read as a small tag rather than a highlight, which undercuts the point of the feature. There is no tracked GitHub issue for this; it was found while reviewing the add-on UI.

## Change

- Move the message out of the title into its own block element, rendered as the first child of the add-on card.
- Style it as a full-bleed solid-accent strip across the top of the highlighted add-on card, using the same uppercase, letter-spaced, centred treatment as the product-level highlight banner. Text wraps freely, so there is no clipping at any width.
- Give the highlighted add-on card a faint accent border and clip its corners so the strip sits flush inside the rounded card.
- Drop the flex layout from the add-on title, which only existed to hold the pill.

Reusing the product-level banner language one level down means a highlighted add-on is instantly recognisable, and the strip scales with the narrower inset card. Inactive add-ons (parent product not yet selected) keep the existing dimmed treatment, so the strip fades with the rest of the card. Multiple highlighted add-ons stack as separate cards with their own strips.

## Verification

- `npx tsc --noEmit` clean for the changed component.
- Checked on the dev stack against the conference demo event: strip correct in dimmed and active states at desktop width; a long message wraps cleanly at a narrow viewport and sits consistently above a product-level banner; two adjacent highlighted add-ons render as distinct cards.
- No new user-facing strings; the organiser-side product form preview renders the real widget and picks this up automatically.