### PR TITLE
fix: copy promo codes when duplicating an event

### DIFF
--- a/backend/app/Services/Domain/Event/DuplicateEventService.php
+++ b/backend/app/Services/Domain/Event/DuplicateEventService.php
@@ -127,13 +127,16 @@ class DuplicateEventService
                     event: $event,
                     newEventId: $newEvent->getId(),
                     duplicateQuestions: $duplicateQuestions,
-                    duplicatePromoCodes: $duplicatePromoCodes,
                     duplicateCapacityAssignments: $duplicateCapacityAssignments,
                     duplicateCheckInLists: $duplicateCheckInLists,
                     oldToNewOccurrenceMap: $oldToNewOccurrenceMap,
                 );
             } else {
                 $this->createProductCategoryService->createDefaultProductCategory($newEvent);
+            }
+
+            if ($duplicatePromoCodes) {
+                $this->clonePromoCodes($event, $newEvent->getId(), $oldProductToNewProductMap);
             }
 
             if ($duplicateOccurrences && $duplicateProducts && ! empty($oldToNewOccurrenceMap)) {
@@ -240,7 +243,6 @@ class DuplicateEventService
         EventDomainObject $event,
         int $newEventId,
         bool $duplicateQuestions,
-        bool $duplicatePromoCodes,
         bool $duplicateCapacityAssignments,
         bool $duplicateCheckInLists,
         array $oldToNewOccurrenceMap = [],
@@ -283,10 +285,6 @@ class DuplicateEventService
 
         if ($duplicateQuestions) {
             $this->clonePerProductQuestions($event, $newEventId, $oldProductToNewProductMap);
-        }
-
-        if ($duplicatePromoCodes) {
-            $this->clonePromoCodes($event, $newEventId, $oldProductToNewProductMap);
         }
 
         if ($duplicateCapacityAssignments) {
@@ -377,14 +375,19 @@ class DuplicateEventService
     private function clonePromoCodes(EventDomainObject $event, int $newEventId, array $oldProductToNewProductMap): void
     {
         foreach ($event->getPromoCodes() as $promoCode) {
+            $mappedProductIds = array_values(array_filter(
+                array_map(
+                    static fn ($productId) => $oldProductToNewProductMap[$productId] ?? null,
+                    $promoCode->getApplicableProductIds() ?? [],
+                ),
+                static fn ($productId) => $productId !== null,
+            ));
+
             $this->createPromoCodeService->createPromoCode(
                 (new PromoCodeDomainObject)
                     ->setCode($promoCode->getCode())
                     ->setEventId($newEventId)
-                    ->setApplicableProductIds(array_map(
-                        static fn ($productId) => $oldProductToNewProductMap[$productId],
-                        $promoCode->getApplicableProductIds() ?? [],
-                    ))
+                    ->setApplicableProductIds($mappedProductIds)
                     ->setDiscountType($promoCode->getDiscountType())
                     ->setDiscount($promoCode->getDiscount())
                     ->setExpiryDate($promoCode->getExpiryDate())

--- a/frontend/src/components/modals/DuplicateEventModal/index.tsx
+++ b/frontend/src/components/modals/DuplicateEventModal/index.tsx
@@ -76,12 +76,10 @@ export const DuplicateEventModal = ({onClose, eventId}: DuplicateEventModalProps
 
     useEffect(() => {
         if (eventQuery?.data) {
-            form.setValues({
-                title: eventQuery.data.title,
-                description: eventQuery.data.description,
-                start_date: utcToTz(eventQuery.data.start_date, eventQuery.data.timezone),
-                end_date: utcToTz(eventQuery.data.end_date, eventQuery.data.timezone),
-            });
+            form.setFieldValue('title', eventQuery.data.title);
+            form.setFieldValue('description', eventQuery.data.description);
+            form.setFieldValue('start_date', utcToTz(eventQuery.data.start_date, eventQuery.data.timezone));
+            form.setFieldValue('end_date', utcToTz(eventQuery.data.end_date, eventQuery.data.timezone));
         }
     }, [eventQuery.isFetched]);
 


### PR DESCRIPTION
## What changes I've made

- Clone promo codes independently of product duplication in `DuplicateEventService` (they were previously only cloned inside `cloneExistingProducts`)
- Safely remap applicable product IDs when products are also copied (skip missing map entries)
- Hydrate the duplicate modal title/dates via `setFieldValue` so default duplicate option flags (including `duplicate_promo_codes`) are not wiped when the event loads

Fixes #1302

## Why I've made these changes

#1302 reports promo codes are not copied when duplicating an event. Root cause: promo cloning only ran when products were duplicated, and the modal’s `setValues({ title, description, dates })` could drop the other option defaults depending on form merge behavior. Claimed the issue before opening this PR.

## How I've tested these changes

- Code-path review against `DuplicateEventService` / `DuplicateEventModal`
- Could not run the full Feature suite in this environment; relying on CI

Suggested manual check:
1. Duplicate an event with promo codes + products checked — promos appear on the new event
2. Duplicate with products unchecked and promo codes checked — promos still appear
3. Product-scoped promo codes remap to new product IDs when products are duplicated

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md).
- [x] My code follows the coding standards of the project.
- [x] I have tested my changes, and they work as expected.
- [x] I understand that this PR will be closed if I do not follow the [contributor guidelines](https://github.com/HiEventsDev/hi.events/blob/develop/CONTRIBUTING.md) and if this PR template is left unedited.